### PR TITLE
fix: misc fixes (bad link to old docs, composio print statement, context window selection)

### DIFF
--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -10,7 +10,7 @@ import letta.utils as utils
 from letta import create_client
 from letta.agent import Agent, save_agent
 from letta.config import LettaConfig
-from letta.constants import CLI_WARNING_PREFIX, LETTA_DIR
+from letta.constants import CLI_WARNING_PREFIX, LETTA_DIR, MIN_CONTEXT_WINDOW
 from letta.local_llm.constants import ASSISTANT_MESSAGE_CLI_SYMBOL
 from letta.log import get_logger
 from letta.metadata import MetadataStore
@@ -243,6 +243,17 @@ def run(
         else:
             llm_model_name = questionary.select("Select LLM model:", choices=llm_choices).ask().model
         llm_config = [llm_config for llm_config in llm_configs if llm_config.model == llm_model_name][0]
+
+        # option to override context window
+        if llm_config.context_window is not None:
+            context_window_validator = lambda x: x.isdigit() and int(x) > MIN_CONTEXT_WINDOW and int(x) <= llm_config.context_window
+            context_window_input = questionary.text(
+                "Context window (hit enter for default):", default=str(llm_config.context_window), validate=context_window_validator
+            ).ask()
+            if context_window_input is not None:
+                llm_config.context_window = int(context_window_input)
+            else:
+                sys.exit(1)
 
         # choose form list of embedding configs
         embedding_configs = client.list_embedding_configs()

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -248,7 +248,7 @@ def run(
         if llm_config.context_window is not None:
             context_window_validator = lambda x: x.isdigit() and int(x) > MIN_CONTEXT_WINDOW and int(x) <= llm_config.context_window
             context_window_input = questionary.text(
-                "Select context window limit (hit enter for default):",
+                "Select LLM context window limit (hit enter for default):",
                 default=str(llm_config.context_window),
                 validate=context_window_validator,
             ).ask()

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -248,7 +248,9 @@ def run(
         if llm_config.context_window is not None:
             context_window_validator = lambda x: x.isdigit() and int(x) > MIN_CONTEXT_WINDOW and int(x) <= llm_config.context_window
             context_window_input = questionary.text(
-                "Context window (hit enter for default):", default=str(llm_config.context_window), validate=context_window_validator
+                "Select context window limit (hit enter for default):",
+                default=str(llm_config.context_window),
+                validate=context_window_validator,
             ).ask()
             if context_window_input is not None:
                 llm_config.context_window = int(context_window_input)

--- a/letta/constants.py
+++ b/letta/constants.py
@@ -18,6 +18,9 @@ IN_CONTEXT_MEMORY_KEYWORD = "CORE_MEMORY"
 # OpenAI error message: Invalid 'messages[1].tool_calls[0].id': string too long. Expected a string with maximum length 29, but got a string with length 36 instead.
 TOOL_CALL_ID_MAX_LEN = 29
 
+# minimum context window size
+MIN_CONTEXT_WINDOW = 4000
+
 # embeddings
 MAX_EMBEDDING_DIM = 4096  # maximum supported embeding size - do NOT change or else DBs will need to be reset
 

--- a/letta/main.py
+++ b/letta/main.py
@@ -26,6 +26,9 @@ from letta.streaming_interface import AgentRefreshStreamingInterface
 
 # interface = interface()
 
+# disable composio print on exit
+os.environ["COMPOSIO_DISABLE_VERSION_CHECK"] = "true"
+
 app = typer.Typer(pretty_exceptions_enable=False)
 app.command(name="run")(run)
 app.command(name="version")(version)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import typer
 
 typer.secho(
-    "Command `python main.py` no longer supported. Please run `letta run`. See https://letta.readme.io/docs/quickstart.",
+    "Command `python main.py` no longer supported. Please run `letta run`. See https://docs.letta.com for more info.",
     fg=typer.colors.YELLOW,
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,13 @@ def test_letta_run_create_new_agent(swap_letta_config):
     except (pexpect.TIMEOUT, pexpect.EOF):
         print("[WARNING] LLM model selection step was skipped.")
 
+    # Optional: Context window selection
+    try:
+        child.expect("Select context window limit (hit enter for default):", timeout=20)
+        child.sendline("")
+    except (pexpect.TIMEOUT, pexpect.EOF):
+        print("[WARNING] Context window selection step was skipped.")
+
     # Optional: Embedding model selection
     try:
         child.expect("Select embedding model:", timeout=20)
@@ -63,6 +70,7 @@ def test_letta_run_create_new_agent(swap_letta_config):
     child.expect("Enter your message:", timeout=60)
     # Capture the output up to this point
     full_output = child.before
+    assert full_output is not None, "No output was captured."
     # Count occurrences of inner thoughts
     cloud_emoji_count = full_output.count(INNER_THOUGHTS_CLI_SYMBOL)
     assert cloud_emoji_count == 1, f"It appears that there are multiple instances of inner thought outputted."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,7 @@ def test_letta_run_create_new_agent(swap_letta_config):
 
     # Optional: Context window selection
     try:
-        child.expect("Select context window limit (hit enter for default):", timeout=20)
+        child.expect("Select LLM context window limit", timeout=20)
         child.sendline("")
     except (pexpect.TIMEOUT, pexpect.EOF):
         print("[WARNING] Context window selection step was skipped.")


### PR DESCRIPTION
- disabled composio print statement
- fixed link to old readme docs when you to `python main.py` (from ancient youtube videos)
- made it so that the CLI flow has an easy way to change the context window
  - **important note**: there's a min context window and a max (the provider's output) for the `questionary` input field

```
% letta run
Initializing database...

🧬 Creating new agent...
? Select LLM model: letta-free [type=openai] [ip=https://inference.memgpt.ai]
? Context window (hit enter for default): 6000
? Select embedding model: letta-free [type=hugging-face] [ip=https://embeddings.memgpt.ai]
->  🤖 Using persona profile: 'sam_pov'
->  🧑 Using human profile: 'basic'
->  🛠️  7 tools: send_message, conversation_search, conversation_search_date, archival_memory_insert, archival_memory_search, core_memory_append, core_memory_replace
/Users/loaner/dev/MemGPT-fresh/letta/agent.py:251: UserWarning: Tool rules only work reliably for the latest OpenAI models that support structured outputs.
  warnings.warn("Tool rules only work reliably for the latest OpenAI models that support structured outputs.")
🎉 Created new agent 'BenevolentUmbrella' (id=agent-a655de82-78df-47ba-b7f9-17ca65c90dfa)

Hit enter to begin (will request first Letta message)
```