### PR TITLE
refactor: patching openapi schema

### DIFF
--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -1,13 +1,13 @@
-from typing import List, Union
+from typing import List
 
 from pydantic import BaseModel, Field
 
 from letta.constants import DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
-from letta.schemas.message import Message, MessageCreate
+from letta.schemas.message import MessageCreate
 
 
 class LettaRequest(BaseModel):
-    messages: Union[List[MessageCreate], List[Message]] = Field(..., description="The messages to be sent to the agent.")
+    messages: List[MessageCreate] = Field(..., description="The messages to be sent to the agent.")
     run_async: bool = Field(default=False, description="Whether to asynchronously send the messages to the agent.")  # TODO: implement
 
     stream_steps: bool = Field(

--- a/letta/schemas/letta_response.py
+++ b/letta/schemas/letta_response.py
@@ -3,7 +3,7 @@ import json
 import re
 from typing import List, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 from letta.schemas.enums import MessageStreamStatus
 from letta.schemas.letta_message import LettaMessage, LettaMessageUnion
@@ -12,6 +12,20 @@ from letta.schemas.usage import LettaUsageStatistics
 from letta.utils import json_dumps
 
 # TODO: consider moving into own file
+
+
+class MessageListResponse(RootModel):
+    root: List[Message]
+
+    class Config:
+        title = "MessageListResponse"  # Explicit title for Stainless
+
+
+class LettaMessageListResponse(RootModel):
+    root: List[LettaMessageUnion]
+
+    class Config:
+        title = "LettaMessageListResponse"  # Explicit title for Stainless
 
 
 class LettaResponse(BaseModel):

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -376,8 +376,14 @@ def update_message(
         200: {
             "description": "Successful response",
             "content": {
-                "application/json": {"$ref": "#/components/schemas/LettaResponse"},  # Use model_json_schema() instead of model directly
-                "text/event-stream": {"description": "Server-Sent Events stream"},
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/LettaResponse",
+                    },
+                },
+                "text/event-stream": {
+                    "description": "Server-Sent Events stream",
+                },
             },
         }
     },

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -8,13 +8,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from letta.constants import DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
 from letta.schemas.agent import AgentState, CreateAgent, UpdateAgentState
 from letta.schemas.enums import MessageStreamStatus
-from letta.schemas.letta_message import (
-    LegacyLettaMessage,
-    LettaMessage,
-    LettaMessageUnion,
-)
+from letta.schemas.letta_message import LegacyLettaMessage, LettaMessage
 from letta.schemas.letta_request import LettaRequest
-from letta.schemas.letta_response import LettaResponse
+from letta.schemas.letta_response import (
+    LettaMessageListResponse,
+    LettaResponse,
+    MessageListResponse,
+)
 from letta.schemas.memory import (
     ArchivalMemorySummary,
     BasicBlockMemory,
@@ -310,7 +310,11 @@ def delete_agent_archival_memory(
     return JSONResponse(status_code=status.HTTP_200_OK, content={"message": f"Memory id={memory_id} successfully deleted"})
 
 
-@router.get("/{agent_id}/messages", response_model=Union[List[Message], List[LettaMessageUnion]], operation_id="list_agent_messages")
+@router.get(
+    "/{agent_id}/messages",
+    response_model=Union[MessageListResponse, LettaMessageListResponse],
+    operation_id="list_agent_messages",
+)
 def get_agent_messages(
     agent_id: str,
     server: "SyncServer" = Depends(get_letta_server),


### PR DESCRIPTION
Fix issues w/ autogenerated SDK workflow

API changes:
1. Send message modified to only allow `List[MessageCreate]` instead of `Union[List[Message], List[MessageCreate]]`
2. Get messages modified to be a `Union` over special types that have names, instead of just a union of `Message` and `LettaMessageUnion`

Related error for (2):
```
Could not infer a name for the union variant.
openapi:2382Schema/CannotInferUnionVariantName
The name for a union variant is inferred from
* a model definition
* a title property on a schema
OpenAPI: #›paths›/v1/agents/{agent_id}/messages›get›responses›200›content›application/json›schema›anyOf›0
```