### PR TITLE
fix: Fix Docker compose startup issues (letta-ai#2056)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,11 +15,17 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U letta"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   letta_server:
     image: letta/letta:latest
     hostname: letta
     depends_on:
-      - letta_db
+      letta_db:
+        condition: service_healthy
     ports:
       - "8083:8083"
       - "8283:8283"

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,8 +6,6 @@ http {
         listen [::]:80;
         listen 8283;
         listen [::]:8283;
-        listen 8283;
-        listen [::]:8283;
         server_name letta.localhost;
         set $api_target "http://letta-server:8283";
         location / {


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR fixes two Docker compose startup issues:
1. Removes duplicate nginx port listener configuration that causes nginx container to fail
2. Adds proper database healthcheck to ensure Letta server only starts after database is ready to accept connections

**How to test**
1. Pull the changes and run:
```bash
docker compose up
```

Expected outcomes:
- All three containers should start successfully, as shown:
```bash
[+] Running 4/3
 ✔ Network letta_default           Created                                                                                                              0.0s 
 ✔ Container letta-letta_db-1      Created                                                                                                              0.1s 
 ✔ Container letta-letta_nginx-1   Created                                                                                                              0.1s 
 ✔ Container letta-letta_server-1  Created
```
- No duplicate port listener error from nginx
- No database connection errors from Letta server
- System should be fully operational after startup completes

**Have you tested this PR?**
Yes, tested the latest commit. The system starts up cleanly as shown in the test output above, with all services starting and remaining running, with no connection errors.

**Related issues or PRs**
Fixes #2056

**Is your PR over 500 lines of code?**
No, this PR makes minimal targeted changes to nginx.conf and compose.yaml.

**Additional context**
These changes ensure reliable container startup sequence by:
- Cleaning up nginx configuration
- Using Docker's healthcheck feature to coordinate service startup
- Preventing race conditions in database connectivity