### PR TITLE
fix: shared memory without requiring send message

### DIFF
--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -1368,8 +1368,9 @@ class SyncServer(Server):
         # Get the agent object (loaded in memory)
         letta_agent = self._get_or_load_agent(agent_id=agent_id)
         assert isinstance(letta_agent.memory, Memory)
-        agent_state = letta_agent.agent_state.model_copy(deep=True)
 
+        letta_agent.update_memory_blocks()
+        agent_state = letta_agent.agent_state.model_copy(deep=True)
         # Load the tags in for the agent_state
         agent_state.tags = self.agents_tags_manager.get_tags_for_agent(agent_id=agent_id, actor=user)
         return agent_state

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -1369,7 +1369,7 @@ class SyncServer(Server):
         letta_agent = self._get_or_load_agent(agent_id=agent_id)
         assert isinstance(letta_agent.memory, Memory)
 
-        letta_agent.update_memory_blocks()
+        letta_agent.update_memory_blocks_from_db()
         agent_state = letta_agent.agent_state.model_copy(deep=True)
         # Load the tags in for the agent_state
         agent_state.tags = self.agents_tags_manager.get_tags_for_agent(agent_id=agent_id, actor=user)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?
This fixes PR fixes a bug where memory shared between multiple agents does not update correctly. The reason is that updated values are only loaded in the agent step. This requires the agent to receive a message to receive update values from shared memory. 

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
Run the test `pytest -s tests/test_local_client.py::test_shared_blocks_without_send_message`
