### PR TITLE
fix: fix bug where updates sets block limit to default value

### DIFF
--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -893,8 +893,8 @@ class RESTClient(AbstractClient):
         else:
             return Block(**response.json())
 
-    def update_block(self, block_id: str, name: Optional[str] = None, text: Optional[str] = None) -> Block:
-        request = BlockUpdate(id=block_id, template_name=name, value=text)
+    def update_block(self, block_id: str, name: Optional[str] = None, text: Optional[str] = None, limit: Optional[int] = None) -> Block:
+        request = BlockUpdate(id=block_id, template_name=name, value=text, limit=limit)
         response = requests.post(f"{self.base_url}/{self.api_prefix}/blocks/{block_id}", json=request.model_dump(), headers=self.headers)
         if response.status_code != 200:
             raise ValueError(f"Failed to update block: {response.text}")
@@ -2680,7 +2680,7 @@ class LocalClient(AbstractClient):
             Block(label=label, template_name=template_name, value=value, is_template=is_template), actor=self.user
         )
 
-    def update_block(self, block_id: str, name: Optional[str] = None, text: Optional[str] = None) -> Block:
+    def update_block(self, block_id: str, name: Optional[str] = None, text: Optional[str] = None, limit: Optional[int] = None) -> Block:
         """
         Update a block
 
@@ -2693,7 +2693,9 @@ class LocalClient(AbstractClient):
             block (Block): Updated block
         """
         return self.server.block_manager.update_block(
-            block_id=block_id, block_update=BlockUpdate(template_name=name, value=text), actor=self.user
+            block_id=block_id,
+            block_update=BlockUpdate(template_name=name, value=text, limit=limit if limit else self.get_block(block_id).limit),
+            actor=self.user,
         )
 
     def get_block(self, block_id: str) -> Block:

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -894,7 +894,7 @@ class RESTClient(AbstractClient):
             return Block(**response.json())
 
     def update_block(self, block_id: str, name: Optional[str] = None, text: Optional[str] = None, limit: Optional[int] = None) -> Block:
-        request = BlockUpdate(id=block_id, template_name=name, value=text, limit=limit)
+        request = BlockUpdate(id=block_id, template_name=name, value=text, limit=limit if limit else self.get_block(block_id).limit)
         response = requests.post(f"{self.base_url}/{self.api_prefix}/blocks/{block_id}", json=request.model_dump(), headers=self.headers)
         if response.status_code != 200:
             raise ValueError(f"Failed to update block: {response.text}")

--- a/letta/services/block_manager.py
+++ b/letta/services/block_manager.py
@@ -34,7 +34,7 @@ class BlockManager:
             return block.to_pydantic()
 
     @enforce_types
-    def update_block(self, block_id: str, block_update: BlockUpdate, actor: PydanticUser) -> PydanticBlock:
+    def update_block(self, block_id: str, block_update: BlockUpdate, actor: PydanticUser, limit: Optional[int] = None) -> PydanticBlock:
         """Update a block by its ID with the given BlockUpdate object."""
         with self.session_maker() as session:
             block = BlockModel.read(db_session=session, identifier=block_id, actor=actor)

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -503,6 +503,29 @@ def test_update_block(server: SyncServer, default_user):
     assert updated_block.description == "Updated description"
 
 
+def test_update_block_limit(server: SyncServer, default_user):
+
+    block_manager = BlockManager()
+    block = block_manager.create_or_update_block(PydanticBlock(label="persona", value="Original Content"), actor=default_user)
+
+    limit = len("Updated Content") * 2000
+    update_data = BlockUpdate(value="Updated Content" * 2000, description="Updated description", limit=limit)
+
+    # Check that a large block fails
+    try:
+        block_manager.update_block(block_id=block.id, block_update=update_data, actor=default_user)
+        assert False
+    except Exception:
+        pass
+
+    block_manager.update_block(block_id=block.id, block_update=update_data, actor=default_user, limit=limit)
+    # Retrieve the updated block
+    updated_block = block_manager.get_blocks(actor=default_user, id=block.id)[0]
+    # Assertions to verify the update
+    assert updated_block.value == "Updated Content" * 2000
+    assert updated_block.description == "Updated description"
+
+
 def test_delete_block(server: SyncServer, default_user):
     block_manager = BlockManager()
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Updating blocks with length greater than the default length throws an error due to the default limit value of `BlockUpdate`. This PR allows setting limits for `BlockUpdate` so that updates larger than the default limit are allowed. 

**How to test**
 Run the test `pytest -s tests/test_managers.py::test_update_block_limit`