### PR TITLE
feat: use token limits in core memory instead of character limits

### DIFF
--- a/letta/constants.py
+++ b/letta/constants.py
@@ -161,3 +161,6 @@ CORE_MEMORY_HUMAN_CHAR_LIMIT: int = 2000
 
 MAX_FILENAME_LENGTH = 255
 RESERVED_FILENAMES = {"CON", "PRN", "AUX", "NUL", "COM1", "COM2", "LPT1", "LPT2"}
+
+# Default tokenizer model to use with tiktoken
+DEFAULT_TIKTOKEN_MODEL = "gpt-4"

--- a/letta/schemas/memory.py
+++ b/letta/schemas/memory.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 if TYPE_CHECKING:
     from letta.agent import Agent
 
+from letta.constants import DEFAULT_TIKTOKEN_MODEL
 from letta.schemas.block import Block
 from letta.schemas.message import Message
 from letta.schemas.openai.chat_completion_request import Tool
@@ -67,7 +68,7 @@ class Memory(BaseModel, validate_assignment=True):
     # Memory.template is a Jinja2 template for compiling memory module into a prompt string.
     prompt_template: str = Field(
         default="{% for block in memory.values() %}"
-        '<{{ block.label }} characters="{{ block.value|length }}/{{ block.limit }}">\n'
+        '<{{ block.label }} tokens="{{ block.value|length }}/{{ block.limit }}">\n'
         "{{ block.value }}\n"
         "</{{ block.label }}>"
         "{% if not loop.last %}\n{% endif %}"
@@ -237,18 +238,18 @@ class ChatMemory(BasicBlockMemory):
     ChatMemory initializes a BaseChatMemory with two default blocks, `human` and `persona`.
     """
 
-    def __init__(self, persona: str, human: str, limit: int = 2000):
+    def __init__(self, persona: str, human: str, limit: int = 2000, tokenizer_model: str = DEFAULT_TIKTOKEN_MODEL):
         """
         Initialize the ChatMemory object with a persona and human string.
 
         Args:
             persona (str): The starter value for the persona block.
             human (str): The starter value for the human block.
-            limit (int): The character limit for each block.
+            limit (int): The token limit for each block.
         """
         super().__init__()
-        self.link_block(block=Block(value=persona, limit=limit, label="persona"))
-        self.link_block(block=Block(value=human, limit=limit, label="human"))
+        self.link_block(block=Block(value=persona, limit=limit, label="persona", tokenizer_model=tokenizer_model))
+        self.link_block(block=Block(value=human, limit=limit, label="human", tokenizer_model=tokenizer_model))
 
 
 class UpdateMemory(BaseModel):


### PR DESCRIPTION
2000 tokens is a good starting point? (~8k chars)

TODOs for later PR:
- [ ] Initialize the `tokenizer_model` in the `Memory` class to be drawn from `agent.llm_config.model`
- [ ] Make sure that when the `agent.llm_config.model` is changed, the `memory.tokenizer_model` is changed too