### PR TITLE
fix: add more types to the type_map from python -> json schema

### DIFF
--- a/letta/functions/schema_generator.py
+++ b/letta/functions/schema_generator.py
@@ -56,7 +56,7 @@ def type_to_json_schema_type(py_type):
         None: "null",
         type(None): "null",
         # Optional types
-        Optional[str]: "string",
+        # Optional[str]: "string",  # NOTE: caught above ^
         Union[str, None]: "string",
     }
     if py_type not in type_map:

--- a/letta/functions/schema_generator.py
+++ b/letta/functions/schema_generator.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Dict, Optional, Type, Union, get_args, get_origin
+from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
 
 from docstring_parser import parse
 from pydantic import BaseModel
@@ -38,15 +38,29 @@ def type_to_json_schema_type(py_type):
 
     # Mapping of Python types to JSON schema types
     type_map = {
+        # Basic types
         int: "integer",
         str: "string",
         bool: "boolean",
         float: "number",
-        list[str]: "array",
-        # Add more mappings as needed
+        # Collections
+        List[str]: "array",
+        List[int]: "array",
+        list: "array",
+        tuple: "array",
+        set: "array",
+        # Dictionaries
+        dict: "object",
+        Dict[str, Any]: "object",
+        # Special types
+        None: "null",
+        type(None): "null",
+        # Optional types
+        Optional[str]: "string",
+        Union[str, None]: "string",
     }
     if py_type not in type_map:
-        raise ValueError(f"Python type {py_type} has no corresponding JSON schema type")
+        raise ValueError(f"Python type {py_type} has no corresponding JSON schema type - full map: {type_map}")
 
     return type_map.get(py_type, "string")  # Default to "string" if type not in map
 

--- a/letta/local_llm/utils.py
+++ b/letta/local_llm/utils.py
@@ -88,7 +88,7 @@ def num_tokens_from_functions(functions: List[dict], model: str = "gpt-4"):
     try:
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:
-        print("Warning: model not found. Using cl100k_base encoding.")
+        warnings.warn("Warning: model not found. Using cl100k_base encoding.")
         encoding = tiktoken.get_encoding("cl100k_base")
 
     num_tokens = 0


### PR DESCRIPTION
Without this, the following tool can't get added (`list` doesn't work, neither does `List[str]`):

```python
def analyze_campaign(campaign_name: str, metrics: list, time_range: str) -> str:
    """
    Evaluate campaign performance metrics.

    Args:
        campaign_name (str): Name of the campaign.
        metrics (list): List of performance metrics to evaluate.
        time_range (str): Time range for analysis (e.g., 'last_week').

    Returns:
        str: Campaign performance summary.
    """
    import random
    performance_data = {
        "meeting_requests": random.randint(5, 20),
        "meetings_booked": random.randint(10, 30),
        "pipeline_generated": f"${random.randint(100000, 500000):,}",
        "closed_won": f"${random.randint(50000, 300000):,}"
    }
    performance_summary = ", ".join([f"{metric}: {performance_data.get(metric, 'N/A')}" for metric in metrics])
    return f"Campaign: {campaign_name} | {performance_summary} in {time_range}."
```