### PR TITLE
fix: do a pre-validation validation on the inputs assigned to `agent_state.message_ids`

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -1325,6 +1325,12 @@ class Agent(BaseAgent):
 
     def update_state(self) -> AgentState:
         message_ids = [msg.id for msg in self._messages]
+
+        # Assert that these are all strings
+        if any(not isinstance(m_id, str) for m_id in message_ids):
+            warnings.warn(f"Non-string message IDs found in agent state: {message_ids}")
+            message_ids = [m_id for m_id in message_ids if isinstance(m_id, str)]
+
         assert isinstance(self.memory, Memory), f"Memory is not a Memory object: {type(self.memory)}"
 
         # override any fields that may have been updated


### PR DESCRIPTION
Bug:
```
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/letta/server/rest_api/routers/v1/agents.py", line 105, in update_agent
    return server.update_agent(update_agent, actor=actor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/letta/server/server.py", line 968, in update_agent
    _ = self.update_agent_core_memory(user_id=actor.id, agent_id=request.id, new_memory_contents=new_memory_contents)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/letta/server/server.py", line 1464, in update_agent_core_memory
    save_agent(letta_agent, self.ms)
  File "/letta/agent.py", line 1624, in save_agent
    agent.update_state()
  File "/letta/agent.py", line 1331, in update_state
    self.agent_state.message_ids = message_ids
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/pydantic/main.py", line 881, in __setattr__
    self.__pydantic_validator__.validate_assignment(self, name, value)
pydantic_core._pydantic_core.ValidationError: 1 validation error for AgentState
  Assertion failed,  [type=assertion_error, input_value=AgentState(description=No... azure_deployment=None)), input_type=AgentState]
```