### PR TITLE
feat: Add locking to send message

### DIFF
--- a/letta/metadata.py
+++ b/letta/metadata.py
@@ -25,6 +25,7 @@ from letta.schemas.tool_rule import (
     ToolRule,
 )
 from letta.schemas.user import User
+from letta.services.per_agent_lock_manager import PerAgentLockManager
 from letta.settings import settings
 from letta.utils import enforce_types, get_utc_time, printd
 
@@ -383,7 +384,11 @@ class MetadataStore:
             session.commit()
 
     @enforce_types
-    def delete_agent(self, agent_id: str):
+    def delete_agent(self, agent_id: str, per_agent_lock_manager: PerAgentLockManager):
+        # TODO: Remove this once Agent is on the ORM
+        # TODO: To prevent unbounded growth
+        per_agent_lock_manager.clear_lock(agent_id)
+
         with self.session_maker() as session:
 
             # delete agents

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -475,7 +475,8 @@ async def send_message(
     """
     actor = server.get_user_or_default(user_id=user_id)
 
-    async with server.send_message_lock:
+    agent_lock = server.per_agent_lock_manager.get_lock(agent_id)
+    async with agent_lock:
         result = await send_message_to_agent(
             server=server,
             agent_id=agent_id,

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -475,19 +475,20 @@ async def send_message(
     """
     actor = server.get_user_or_default(user_id=user_id)
 
-    result = await send_message_to_agent(
-        server=server,
-        agent_id=agent_id,
-        user_id=actor.id,
-        messages=request.messages,
-        stream_steps=request.stream_steps,
-        stream_tokens=request.stream_tokens,
-        return_message_object=request.return_message_object,
-        # Support for AssistantMessage
-        use_assistant_message=request.use_assistant_message,
-        assistant_message_function_name=request.assistant_message_function_name,
-        assistant_message_function_kwarg=request.assistant_message_function_kwarg,
-    )
+    async with server.send_message_lock:
+        result = await send_message_to_agent(
+            server=server,
+            agent_id=agent_id,
+            user_id=actor.id,
+            messages=request.messages,
+            stream_steps=request.stream_steps,
+            stream_tokens=request.stream_tokens,
+            return_message_object=request.return_message_object,
+            # Support for AssistantMessage
+            use_assistant_message=request.use_assistant_message,
+            assistant_message_function_name=request.assistant_message_function_name,
+            assistant_message_function_kwarg=request.assistant_message_function_kwarg,
+        )
     return result
 
 

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -3,6 +3,7 @@ import os
 import traceback
 import warnings
 from abc import abstractmethod
+from asyncio import Lock
 from datetime import datetime
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -230,6 +231,9 @@ class SyncServer(Server):
         self.default_interface_factory = default_interface_factory
 
         self.credentials = LettaCredentials.load()
+
+        # Locks
+        self.send_message_lock = Lock()
 
         # Initialize the metadata store
         config = LettaConfig.load()

--- a/letta/services/per_agent_lock_manager.py
+++ b/letta/services/per_agent_lock_manager.py
@@ -1,0 +1,18 @@
+import asyncio
+from collections import defaultdict
+
+
+class PerAgentLockManager:
+    """Manages per-agent locks."""
+
+    def __init__(self):
+        self.locks = defaultdict(asyncio.Lock)
+
+    def get_lock(self, agent_id: str) -> asyncio.Lock:
+        """Retrieve the lock for a specific agent_id."""
+        return self.locks[agent_id]
+
+    def clear_lock(self, agent_id: str):
+        """Optionally remove a lock if no longer needed (to prevent unbounded growth)."""
+        if agent_id in self.locks:
+            del self.locks[agent_id]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,7 +40,7 @@ def run_server():
 
 
 @pytest.fixture(
-    params=[{"server": True}],  # whether to use REST API server
+    params=[{"server": True}, {"server": False}],  # whether to use REST API server
     scope="module",
 )
 def client(request):
@@ -309,10 +309,12 @@ def test_messages(client: Union[LocalClient, RESTClient], agent: AgentState):
 
 
 @pytest.mark.asyncio
-async def test_send_message_parallel(client: Union[LocalClient, RESTClient], agent: AgentState):
+async def test_send_message_parallel(client: Union[LocalClient, RESTClient], agent: AgentState, request):
     """
     Test that sending two messages in parallel does not error.
     """
+    if not isinstance(client, RESTClient):
+        pytest.skip("This test only runs when the server is enabled")
 
     # Define a coroutine for sending a message using asyncio.to_thread for synchronous calls
     async def send_message_task(message: str):

--- a/tests/test_client_legacy.py
+++ b/tests/test_client_legacy.py
@@ -223,16 +223,6 @@ def test_core_memory(client: Union[LocalClient, RESTClient], agent: AgentState):
     assert "Timber" in memory.get_block("human").value, f"Updating core memory failed: {memory.get_block('human').value}"
 
 
-def test_messages(client: Union[LocalClient, RESTClient], agent: AgentState):
-    # _reset_config()
-
-    send_message_response = client.send_message(agent_id=agent.id, message="Test message", role="user")
-    assert send_message_response, "Sending message failed"
-
-    messages_response = client.get_messages(agent_id=agent.id, limit=1)
-    assert len(messages_response) > 0, "Retrieving messages failed"
-
-
 def test_streaming_send_message(client: Union[LocalClient, RESTClient], agent: AgentState):
     if isinstance(client, LocalClient):
         pytest.skip("Skipping test_streaming_send_message because LocalClient does not support streaming")


### PR DESCRIPTION
## Description

This is a short-term fix for `send_message`. If multiple `send_message` calls are sent, due to some state in the interface, it errors. This prevents multiple `send_message` calls from executing at the same time for the same agent.

## Testing 

We write a test simulating concurrent `send_message` requests. Without the changes in this PR, it errors:

```
FAILED tests/test_client.py::test_send_message_parallel[client0] - Failed: Task 0 failed with exception: Failed to send message: {"detail":"Generator is inactive"}
```