### PR TITLE
fix: move route for `/v1/tools/run`

### DIFF
--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -175,7 +175,7 @@ def add_base_tools(
 #     return server.run_tool(tool_id=request.tool_id, tool_args=request.tool_args, user_id=actor.id)
 
 
-@router.post("/run", response_model=FunctionReturn, operation_id="run_tool_from_source")
+@router.post("/simulate-tool", response_model=FunctionReturn, operation_id="run_tool_from_source")
 def run_tool_from_source(
     server: SyncServer = Depends(get_letta_server),
     request: ToolRunFromSource = Body(...),


### PR DESCRIPTION
Conflict with `/v1/tools/{tool_id}`, moving to `v1/tools/simulate-tool`