### PR TITLE
fix: escape strings in sandbox

### DIFF
--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -3,7 +3,6 @@ import base64
 import io
 import os
 import pickle
-import re
 import runpy
 import sys
 import tempfile
@@ -269,6 +268,9 @@ class ToolExecutionSandbox:
         for param in self.args:
             code += self.initialize_param(param, self.args[param])
 
+        print("CODE")
+        print(code)
+
         if "agent_state" in self.parse_function_arguments(self.tool.source_code, self.tool.name):
             inject_agent_state = True
         else:
@@ -293,7 +295,9 @@ class ToolExecutionSandbox:
     def _convert_param_to_value(self, param_type: str, raw_value: str) -> str:
 
         if param_type == "string":
-            value = '"' + re.escape(raw_value) + '"'
+            # value = '"' + re.escape(raw_value) + '"'
+            print(pickle.dumps(raw_value))
+            value = "pickle.loads(" + str(pickle.dumps(raw_value)) + ")"
 
         elif param_type == "integer" or param_type == "boolean" or param_type == "number":
             value = raw_value

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -292,8 +292,6 @@ class ToolExecutionSandbox:
     def _convert_param_to_value(self, param_type: str, raw_value: str) -> str:
 
         if param_type == "string":
-            # value = '"' + re.escape(raw_value) + '"'
-            print(pickle.dumps(raw_value))
             value = "pickle.loads(" + str(pickle.dumps(raw_value)) + ")"
 
         elif param_type == "integer" or param_type == "boolean" or param_type == "number":

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -3,6 +3,7 @@ import base64
 import io
 import os
 import pickle
+import re
 import runpy
 import sys
 import tempfile
@@ -287,13 +288,12 @@ class ToolExecutionSandbox:
             f"{self.LOCAL_SANDBOX_RESULT_VAR_NAME} = base64.b64encode(pickle.dumps({self.LOCAL_SANDBOX_RESULT_VAR_NAME})).decode('utf-8')\n"
         )
         code += f"{self.LOCAL_SANDBOX_RESULT_VAR_NAME}\n"
-
         return code
 
     def _convert_param_to_value(self, param_type: str, raw_value: str) -> str:
 
         if param_type == "string":
-            value = '"' + raw_value + '"'
+            value = '"' + re.escape(raw_value) + '"'
 
         elif param_type == "integer" or param_type == "boolean" or param_type == "number":
             value = raw_value
@@ -306,7 +306,6 @@ class ToolExecutionSandbox:
 
         else:
             raise TypeError(f"Unsupported type: {param_type}, raw_value={raw_value}")
-
         return str(value)
 
     def initialize_param(self, name: str, raw_value: str) -> str:

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -268,9 +268,6 @@ class ToolExecutionSandbox:
         for param in self.args:
             code += self.initialize_param(param, self.args[param])
 
-        print("CODE")
-        print(code)
-
         if "agent_state" in self.parse_function_arguments(self.tool.source_code, self.tool.name):
             inject_agent_state = True
         else:

--- a/tests/integration_test_tool_execution_sandbox.py
+++ b/tests/integration_test_tool_execution_sandbox.py
@@ -389,6 +389,18 @@ def test_e2b_sandbox_core_memory_replace(check_e2b_key_is_set, core_memory_repla
 
 
 @pytest.mark.e2b_sandbox
+def test_e2b_sandbox_escape_strings_in_args(check_e2b_key_is_set, core_memory_replace_tool, test_user, agent_state):
+    new_name = "Matt"
+    args = {"label": "human", "old_content": "Chad", "new_content": new_name + "\n"}
+    sandbox = ToolExecutionSandbox(core_memory_replace_tool.name, args, user_id=test_user.id)
+
+    # run the sandbox
+    result = sandbox.run(agent_state=agent_state)
+    assert new_name in result.agent_state.memory.get_block("human").value
+    assert result.func_return is None
+
+
+@pytest.mark.e2b_sandbox
 def test_e2b_sandbox_core_memory_replace_errors(check_e2b_key_is_set, core_memory_replace_tool, test_user, agent_state):
     nonexistent_name = "Alexander Wang"
     args = {"label": "human", "old_content": nonexistent_name, "new_content": "Matt"}


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Add escapes to arguments of type string to allow arguments to have newlines etc.