### PR TITLE
fix: Suppress warnings during local sandbox tool execution w/ venv

### DIFF
--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -159,7 +159,7 @@ class ToolExecutionSandbox:
         # Set up env for venv
         env["VIRTUAL_ENV"] = venv_path
         env["PATH"] = os.path.join(venv_path, "bin") + ":" + env["PATH"]
-        # Supress all warnings
+        # Suppress all warnings
         env["PYTHONWARNINGS"] = "ignore"
 
         # Execute the code in a restricted subprocess

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -159,6 +159,8 @@ class ToolExecutionSandbox:
         # Set up env for venv
         env["VIRTUAL_ENV"] = venv_path
         env["PATH"] = os.path.join(venv_path, "bin") + ":" + env["PATH"]
+        # Supress all warnings
+        env["PYTHONWARNINGS"] = "ignore"
 
         # Execute the code in a restricted subprocess
         try:


### PR DESCRIPTION
Suppress warnings during local sandbox tool execution w/ venv. This is causing an issue where, if warnings are outputted during tool execution runtime, we raise an error in the local sandbox w/ a venv.