### PR TITLE
fix: disable printing version in health check, causes spam

### DIFF
--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -370,8 +370,7 @@ def delete_agent(
         sys.exit(1)
 
 
-def version():
+def version() -> str:
     import letta
 
-    print(letta.__version__)
     return letta.__version__


### PR DESCRIPTION
Disable print spam in server logs:
```
INFO:     ::1:54484 - "GET /v1/health/ HTTP/1.1" 200 OK
0.6.1
0.6.1
INFO:     ::1:54473 - "GET /v1/health/ HTTP/1.1" 200 OK
INFO:     ::1:54484 - "GET /v1/health/ HTTP/1.1" 200 OK
INFO:     ::1:54473 - "GET /v1/health HTTP/1.1" 307 Temporary Redirect
INFO:     ::1:54473 - "GET /v1/health HTTP/1.1" 307 Temporary Redirect
0.6.1
INFO:     ::1:54473 - "GET /v1/health/ HTTP/1.1" 200 OK
0.6.1
INFO:     ::1:54473 - "GET /v1/health/ HTTP/1.1" 200 OK
0.6.1
0.6.1
INFO:     ::1:54473 - "GET /v1/health/ HTTP/1.1" 200 OK
INFO:     ::1:54484 - "GET /v1/health/ HTTP/1.1" 200 OK
INFO:     ::1:54484 - "GET /v1/health HTTP/1.1" 307 Temporary Redirect
INFO:     ::1:54484 - "GET /v1/health HTTP/1.1" 307 Temporary Redirect
0.6.1
INFO:     ::1:54484 - "GET /v1/health/ HTTP/1.1" 200 OK
0.6.1
INFO:     ::1:54484 - "GET /v1/health/ HTTP/1.1" 200 OK
0.6.10.6.1
```