### PR TITLE
fix: add a special error type for configuration errors

### DIFF
--- a/letta/errors.py
+++ b/letta/errors.py
@@ -38,6 +38,14 @@ class LettaAgentNotFoundError(LettaError):
         super().__init__(self.message)
 
 
+class LettaUserNotFoundError(LettaError):
+    """Error raised when a user is not found."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
 class LLMError(LettaError):
     pass
 

--- a/letta/errors.py
+++ b/letta/errors.py
@@ -30,6 +30,14 @@ class LettaConfigurationError(LettaError):
         super().__init__(message)
 
 
+class LettaAgentNotFoundError(LettaError):
+    """Error raised when an agent is not found."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
 class LLMError(LettaError):
     pass
 

--- a/letta/errors.py
+++ b/letta/errors.py
@@ -22,6 +22,14 @@ class LettaToolCreateError(LettaError):
         super().__init__(self.message)
 
 
+class LettaConfigurationError(LettaError):
+    """Error raised when there are configuration-related issues."""
+
+    def __init__(self, message: str, missing_fields: Optional[List[str]] = None):
+        self.missing_fields = missing_fields or []
+        super().__init__(message)
+
+
 class LLMError(LettaError):
     pass
 

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -13,7 +13,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from letta.__init__ import __version__
 from letta.constants import ADMIN_PREFIX, API_PREFIX, OPENAI_API_PREFIX
-from letta.errors import LettaAgentNotFoundError
+from letta.errors import LettaAgentNotFoundError, LettaUserNotFoundError
 from letta.schemas.letta_response import LettaResponse
 from letta.server.constants import REST_DEFAULT_PORT
 
@@ -165,6 +165,10 @@ def create_application() -> "FastAPI":
     @app.exception_handler(LettaAgentNotFoundError)
     async def agent_not_found_handler(request, exc):
         return JSONResponse(status_code=404, content={"detail": "Agent not found"})
+
+    @app.exception_handler(LettaUserNotFoundError)
+    async def user_not_found_handler(request, exc):
+        return JSONResponse(status_code=404, content={"detail": "User not found"})
 
     settings.cors_origins.append("https://app.letta.com")
     print(f"▶ View using ADE at: https://app.letta.com/development-servers/local/dashboard")

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -13,6 +13,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from letta.__init__ import __version__
 from letta.constants import ADMIN_PREFIX, API_PREFIX, OPENAI_API_PREFIX
+from letta.errors import LettaAgentNotFoundError
 from letta.schemas.letta_response import LettaResponse
 from letta.server.constants import REST_DEFAULT_PORT
 
@@ -143,6 +144,27 @@ def create_application() -> "FastAPI":
         version="1.0.0",  # TODO wire this up to the version in the package
         debug=True,
     )
+
+    @app.exception_handler(Exception)
+    async def generic_error_handler(request, exc):
+        # Log the actual error for debugging
+        log.error(f"Unhandled error: {exc}", exc_info=True)
+
+        # Print the stack trace
+        print(f"Stack trace: {exc.__traceback__}")
+
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "An internal server error occurred",
+                # Only include error details in debug/development mode
+                # "debug_info": str(exc) if settings.debug else None
+            },
+        )
+
+    @app.exception_handler(LettaAgentNotFoundError)
+    async def agent_not_found_handler(request, exc):
+        return JSONResponse(status_code=404, content={"detail": "Agent not found"})
 
     settings.cors_origins.append("https://app.letta.com")
     print(f"▶ View using ADE at: https://app.letta.com/development-servers/local/dashboard")

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -21,7 +21,7 @@ from letta.agent_store.storage import StorageConnector, TableType
 from letta.chat_only_agent import ChatOnlyAgent
 from letta.credentials import LettaCredentials
 from letta.data_sources.connectors import DataConnector, load_data
-from letta.errors import LettaAgentNotFoundError
+from letta.errors import LettaAgentNotFoundError, LettaUserNotFoundError
 
 # TODO use custom interface
 from letta.interface import AgentInterface  # abstract
@@ -1250,9 +1250,9 @@ class SyncServer(Server):
         reverse: Optional[bool] = False,
     ) -> List[Passage]:
         if self.user_manager.get_user_by_id(user_id=user_id) is None:
-            raise ValueError(f"User user_id={user_id} does not exist")
+            raise LettaUserNotFoundError(f"User user_id={user_id} does not exist")
         if self.ms.get_agent(agent_id=agent_id, user_id=user_id) is None:
-            raise ValueError(f"Agent agent_id={agent_id} does not exist")
+            raise LettaAgentNotFoundError(f"Agent agent_id={agent_id} does not exist")
 
         # Get the agent object (loaded in memory)
         letta_agent = self.load_agent(agent_id=agent_id)

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -21,6 +21,7 @@ from letta.agent_store.storage import StorageConnector, TableType
 from letta.chat_only_agent import ChatOnlyAgent
 from letta.credentials import LettaCredentials
 from letta.data_sources.connectors import DataConnector, load_data
+from letta.errors import LettaAgentNotFoundError
 
 # TODO use custom interface
 from letta.interface import AgentInterface  # abstract
@@ -397,7 +398,7 @@ class SyncServer(Server):
         with agent_lock:
             agent_state = self.get_agent(agent_id=agent_id)
             if agent_state is None:
-                raise ValueError(f"Agent (agent_id={agent_id}) does not exist")
+                raise LettaAgentNotFoundError(f"Agent (agent_id={agent_id}) does not exist")
             elif agent_state.user_id is None:
                 raise ValueError(f"Agent (agent_id={agent_id}) does not have a user_id")
             actor = self.user_manager.get_user_by_id(user_id=agent_state.user_id)


### PR DESCRIPTION
Cleans up some common error triggers on the server side:

- [x] When the server is configured with a model but the API key doesn't exist, the client gets a confusing retry error instead of an API key error
- [x] ADE constantly hits `/agents` routes for `.../context`, `.../archival`, but gets a `500` instead of the correct `404`

---

## Before:

Server-side:
```
INFO:     ::1:56137 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 200 OK
...
Exception: Retries exhausted and no valid response received.
None
Retries exhausted and no valid response received.
...
  File "/Users/loaner/miniconda3/envs/letta/lib/python3.12/site-packages/letta/agent.py", line 641, in _get_ai_reply
    raise Exception("Retries exhausted and no valid response received.")
Exception: Retries exhausted and no valid response received.
```

Client-side:
```
Traceback (most recent call last):
  File "/Users/loaner/miniconda3/envs/letta/lib/python3.12/site-packages/letta/client/client.py", line 975, in send_message
    raise ValueError(f"Failed to send message: {response.text}")
ValueError: Failed to send message: {"detail":"Retries exhausted and no valid response received."}
```

## After:

Server-side:
```
INFO:     Finished server process [65818]
letta-py3.10(base) loaner@MacBook-Pro-8 MemGPT-fresh % letta server

[[ Letta server // v0.6.1 ]]
▶ View using ADE at: https://app.letta.com/development-servers/local/dashboard
▶ Server running at: http://localhost:8283

INFO:     Started server process [65971]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://localhost:8283 (Press CTRL+C to quit)
INFO:     ::1:59716 - "GET /v1/jobs/active HTTP/1.1" 200 OK
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/archival HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/jobs/active HTTP/1.1" 200 OK
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/jobs/active HTTP/1.1" 200 OK
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/archival HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/archival HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/jobs/active HTTP/1.1" 200 OK
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/archival HTTP/1.1" 404 Not Found
INFO:     ::1:59716 - "GET /v1/agents/agent-bbd31eda-8b95-46d3-957e-312ef4fe2911/context HTTP/1.1" 404 Not Found
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
```