### PR TITLE
fix: Modify the `list` ORM function

### DIFF
--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -3074,7 +3074,7 @@ class LocalClient(AbstractClient):
         return self.server.get_agent_recall_cursor(
             user_id=self.user_id,
             agent_id=agent_id,
-            cursor=cursor,
+            before=cursor,
             limit=limit,
             reverse=True,
         )

--- a/letta/orm/sqlalchemy_base.py
+++ b/letta/orm/sqlalchemy_base.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, List, Literal, Optional, Type
 
-from sqlalchemy import String, func, select
+from sqlalchemy import String, desc, func, or_, select
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
@@ -60,14 +60,25 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
         end_date: Optional[datetime] = None,
         limit: Optional[int] = 50,
         query_text: Optional[str] = None,
+        ascending: bool = True,
         **kwargs,
     ) -> List[Type["SqlalchemyBase"]]:
-        """List records with advanced filtering and pagination options."""
+        """
+        List records with cursor-based pagination, ordering by created_at.
+        Cursor is an ID, but pagination is based on the cursor object's created_at value.
+        """
         if start_date and end_date and start_date > end_date:
             raise ValueError("start_date must be earlier than or equal to end_date")
 
         logger.debug(f"Listing {cls.__name__} with kwarg filters {kwargs}")
         with db_session as session:
+            # If cursor provided, get the reference object
+            cursor_obj = None
+            if cursor:
+                cursor_obj = session.get(cls, cursor)
+                if not cursor_obj:
+                    raise NoResultFound(f"No {cls.__name__} found with id {cursor}")
+
             query = select(cls)
 
             # Apply filtering logic
@@ -80,22 +91,38 @@ class SqlalchemyBase(CommonSqlalchemyMetaMixins, Base):
 
             # Date range filtering
             if start_date:
-                query = query.filter(cls.created_at >= start_date)
+                query = query.filter(cls.created_at > start_date)
             if end_date:
-                query = query.filter(cls.created_at <= end_date)
+                query = query.filter(cls.created_at < end_date)
 
-            # Cursor-based pagination
-            if cursor:
-                query = query.where(cls.id > cursor)
+            # Cursor-based pagination using created_at
+            # TODO: There is a really nasty race condition issue here with Sqlite
+            # TODO: If they have the same created_at timestamp, this query does NOT match for whatever reason
+            if cursor_obj:
+                if ascending:
+                    query = query.where(cls.created_at >= cursor_obj.created_at).where(
+                        or_(cls.created_at > cursor_obj.created_at, cls.id > cursor_obj.id)
+                    )
+                else:
+                    query = query.where(cls.created_at <= cursor_obj.created_at).where(
+                        or_(cls.created_at < cursor_obj.created_at, cls.id < cursor_obj.id)
+                    )
 
             # Apply text search
             if query_text:
                 query = query.filter(func.lower(cls.text).contains(func.lower(query_text)))
 
-            # Handle ordering and soft deletes
+            # Handle soft deletes
             if hasattr(cls, "is_deleted"):
                 query = query.where(cls.is_deleted == False)
-            query = query.order_by(cls.id).limit(limit)
+
+            # Apply ordering by created_at
+            if ascending:
+                query = query.order_by(cls.created_at, cls.id)
+            else:
+                query = query.order_by(desc(cls.created_at), desc(cls.id))
+
+            query = query.limit(limit)
 
             return list(session.execute(query).scalars())
 

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -409,7 +409,7 @@ def get_agent_messages(
     return server.get_agent_recall_cursor(
         user_id=actor.id,
         agent_id=agent_id,
-        cursor=before,
+        before=before,
         limit=limit,
         reverse=True,
         return_message_object=msg_object,

--- a/letta/services/message_manager.py
+++ b/letta/services/message_manager.py
@@ -119,6 +119,7 @@ class MessageManager:
         limit: Optional[int] = 50,
         filters: Optional[Dict] = None,
         query_text: Optional[str] = None,
+        ascending: bool = True,
     ) -> List[PydanticMessage]:
         """List user messages with flexible filtering and pagination options.
 
@@ -159,6 +160,7 @@ class MessageManager:
         limit: Optional[int] = 50,
         filters: Optional[Dict] = None,
         query_text: Optional[str] = None,
+        ascending: bool = True,
     ) -> List[PydanticMessage]:
         """List messages with flexible filtering and pagination options.
 
@@ -188,6 +190,7 @@ class MessageManager:
                 end_date=end_date,
                 limit=limit,
                 query_text=query_text,
+                ascending=ascending,
                 **message_filters,
             )
 

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -459,7 +459,7 @@ class ToolExecutionSandbox:
         Generate the code string to call the function.
 
         Args:
-            inject_agent_state (bool): Whether to inject the agent's state as an input into the tool
+            inject_agent_state (bool): Whether to inject the axgent's state as an input into the tool
 
         Returns:
             str: Generated code string for calling the tool

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -161,37 +161,25 @@ def test_user_message(server, user_id, agent_id):
     # server.user_message(user_id=user_id, agent_id=agent_id, message="Hello?")
 
 
-# TODO: Add this back, this is broken on main
-# @pytest.mark.order(5)
-# def test_get_recall_memory(server, org_id, user_id, agent_id):
-#     # test recall memory cursor pagination
-#     messages_1 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, limit=2)
-#     cursor1 = messages_1[-1].id
-#     messages_2 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, after=cursor1, limit=1000)
-#     messages_2[-1].id
-#     messages_3 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, limit=1000)
-#     messages_3[-1].id
-#     assert messages_3[-1].created_at >= messages_3[0].created_at
-#     assert len(messages_3) == len(messages_1) + len(messages_2)
-#     messages_4 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, reverse=True, before=cursor1)
-#     assert len(messages_4) == 1
-#
-#     # test in-context message ids
-#     in_context_ids = server.get_in_context_message_ids(agent_id=agent_id)
-#     message_ids = [m.id for m in messages_3]
-#     for message_id in in_context_ids:
-#         assert message_id in message_ids, f"{message_id} not in {message_ids}"
-#
-#     # test recall memory
-#     messages_1 = server.get_agent_messages(agent_id=agent_id, start=0, count=1)
-#     assert len(messages_1) == 1
-#     messages_2 = server.get_agent_messages(agent_id=agent_id, start=1, count=1000)
-#     messages_3 = server.get_agent_messages(agent_id=agent_id, start=1, count=2)
-#     # not sure exactly how many messages there should be
-#     assert len(messages_2) > len(messages_3)
-#     # test safe empty return
-#     messages_none = server.get_agent_messages(agent_id=agent_id, start=1000, count=1000)
-#     assert len(messages_none) == 0
+@pytest.mark.order(5)
+def test_get_recall_memory(server, org_id, user_id, agent_id):
+    # test recall memory cursor pagination
+    messages_1 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, limit=2)
+    cursor1 = messages_1[-1].id
+    messages_2 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, after=cursor1, limit=1000)
+    messages_2[-1].id
+    messages_3 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, limit=1000)
+    messages_3[-1].id
+    assert messages_3[-1].created_at >= messages_3[0].created_at
+    assert len(messages_3) == len(messages_1) + len(messages_2)
+    messages_4 = server.get_agent_recall_cursor(user_id=user_id, agent_id=agent_id, reverse=True, before=cursor1)
+    assert len(messages_4) == 1
+
+    # test in-context message ids
+    in_context_ids = server.get_in_context_message_ids(agent_id=agent_id)
+    message_ids = [m.id for m in messages_3]
+    for message_id in in_context_ids:
+        assert message_id in message_ids, f"{message_id} not in {message_ids}"
 
 
 @pytest.mark.order(6)


### PR DESCRIPTION
## Description:

Modify the `list` ORM function:
- Allow ascending/descending sorting
- Sort by both created_at and id
- We now retrieve the object given passed in cursor id, and use the `created_at` field to do pagination

Please note, there is a strange race condition with Sqlite as the created_at field is not accurate enough. This should not have any practical effect for the most part, as this is triggered by lines in our tests where we rapidly create a bunch of objects. We are tracking this issue and will find a workaround for Sqlite users.

