### PR TITLE
fix: make healthcheck public

### DIFF
--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -109,7 +109,13 @@ random_password = os.getenv("LETTA_SERVER_PASSWORD") or generate_password()
 
 
 class CheckPasswordMiddleware(BaseHTTPMiddleware):
+
     async def dispatch(self, request, call_next):
+
+        # Exclude health check endpoint from password protection
+        if request.url.path == "/api/v1/health" or request.url.path == "/latest/health":
+            return await call_next(request)
+
         if request.headers.get("X-BARE-PASSWORD") == f"password {random_password}":
             return await call_next(request)
 

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -113,7 +113,7 @@ class CheckPasswordMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
 
         # Exclude health check endpoint from password protection
-        if request.url.path == "/api/v1/health" or request.url.path == "/latest/health":
+        if request.url.path == "/v1/health/" or request.url.path == "/latest/health/":
             return await call_next(request)
 
         if request.headers.get("X-BARE-PASSWORD") == f"password {random_password}":


### PR DESCRIPTION
This is required for PaaS services that accept a healthcheck endpoint (but no header options)