### PR TITLE
fix: pattern match new prints correctly

### DIFF
--- a/.github/workflows/check_for_new_prints.yml
+++ b/.github/workflows/check_for_new_prints.yml
@@ -43,7 +43,7 @@ jobs:
               NEW_PRINTS=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} "$file" | \
                           grep "^+" | \
                           grep -v "^+++" | \
-                          grep "print(" || true)
+                          grep -E "(^|\s)print\("" || true)
 
               if [ ! -z "$NEW_PRINTS" ]; then
                 echo "❌ Found new print statements in $file:"

--- a/.github/workflows/check_for_new_prints.yml
+++ b/.github/workflows/check_for_new_prints.yml
@@ -43,7 +43,7 @@ jobs:
               NEW_PRINTS=$(git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} "$file" | \
                           grep "^+" | \
                           grep -v "^+++" | \
-                          grep -E "(^|\s)print\("" || true)
+                          grep -E "(^|\s)print\(" || true)
 
               if [ ! -z "$NEW_PRINTS" ]; then
                 echo "❌ Found new print statements in $file:"

--- a/letta/services/tool_execution_sandbox.py
+++ b/letta/services/tool_execution_sandbox.py
@@ -201,7 +201,10 @@ class ToolExecutionSandbox:
             func_result, stdout = self.parse_out_function_results_markers(result.stdout)
             func_return, agent_state = self.parse_best_effort(func_result)
             return SandboxRunResult(
-                func_return=func_return, agent_state=agent_state, stdout=[stdout], sandbox_config_fingerprint=sbx_config.fingerprint()
+                func_return=func_return, 
+                agent_state=agent_state, 
+                stdout=[stdout], 
+                sandbox_config_fingerprint=sbx_config.fingerprint(),
             )
         except subprocess.TimeoutExpired:
             raise TimeoutError(f"Executing tool {self.tool_name} has timed out.")


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Noticed this faulty  failing test on PR [#2205](https://github.com/letta-ai/letta/pull/2205)

<img width="1139" alt="Screenshot 2024-12-10 at 9 37 12 AM" src="https://github.com/user-attachments/assets/ce908c23-97a1-4c88-87a3-5bce73576316">

**How to test**
Ensure git test run passes

**Have you tested this PR?**
Before:
```
(letta-py3.12) caren@caren-mac letta % git diff main "letta/services/tool_execution_sandbox.py" | grep "^+" | grep -v "^+++" | grep "print(" || true
+                sandbox_config_fingerprint=sbx_config.fingerprint(),
```
After: 
```
(letta-py3.12) caren@caren-mac letta % git diff main "letta/services/tool_execution_sandbox.py" | grep "^+" | grep -v "^+++" | grep -E "(^|\s)print\(" || true
```

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/Letta/issues) or [PRs](https://github.com/cpacker/Letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
