### PR TITLE
fix: cleanup error trace for no llm/embedding_config on POST

### DIFF
--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
@@ -147,7 +147,7 @@ def create_application() -> "FastAPI":
     )
 
     @app.exception_handler(Exception)
-    async def generic_error_handler(request, exc):
+    async def generic_error_handler(request: Request, exc: Exception):
         # Log the actual error for debugging
         log.error(f"Unhandled error: {exc}", exc_info=True)
 
@@ -167,12 +167,16 @@ def create_application() -> "FastAPI":
             },
         )
 
+    @app.exception_handler(ValueError)
+    async def value_error_handler(request: Request, exc: ValueError):
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
     @app.exception_handler(LettaAgentNotFoundError)
-    async def agent_not_found_handler(request, exc):
+    async def agent_not_found_handler(request: Request, exc: LettaAgentNotFoundError):
         return JSONResponse(status_code=404, content={"detail": "Agent not found"})
 
     @app.exception_handler(LettaUserNotFoundError)
-    async def user_not_found_handler(request, exc):
+    async def user_not_found_handler(request: Request, exc: LettaUserNotFoundError):
         return JSONResponse(status_code=404, content={"detail": "User not found"})
 
     settings.cors_origins.append("https://app.letta.com")

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -136,13 +136,14 @@ def create_application() -> "FastAPI":
             },
         )
 
+    debug_mode = "--debug" in sys.argv
     app = FastAPI(
         swagger_ui_parameters={"docExpansion": "none"},
         # openapi_tags=TAGS_METADATA,
         title="Letta",
         summary="Create LLM agents with long-term memory and custom tools 📚🦙",
         version="1.0.0",  # TODO wire this up to the version in the package
-        debug=True,
+        debug=debug_mode,  # if True, the stack trace will be printed in the response
     )
 
     @app.exception_handler(Exception)

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -824,6 +824,12 @@ class SyncServer(Server):
         if not user:
             raise ValueError(f"cannot find user with associated client id: {user_id}")
 
+        if request.llm_config is None:
+            raise ValueError("llm_config is required")
+
+        if request.embedding_config is None:
+            raise ValueError("embedding_config is required")
+
         # created and persist the agent state in the DB
         agent_state = PersistedAgentState(
             name=request.name,


### PR DESCRIPTION
Before:
```
 curl --request POST \
  --url http://localhost:8283/v1/agents/ \
  --header 'Authorization: Bearer <token>' \
  --header 'Content-Type: application/json' \
  --data '{
  "memory_blocks": [
    {
      "value": "The human'\''s name is Bob the Builder",
      "label": "human"
    },
    {
      "label": "persona",
      "value": "My name is Sam, the all-knowing sentient AI."
    }
  ],
  "name": "agent_sam"
}'
Traceback (most recent call last):
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/letta-JSsUGnlY-py3.10/lib/python3.10/site-...
tta-JSsUGnlY-py3.10/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "/Users/loaner/Library/Caches/pypoetry/virtualenvs/letta-JSsUGnlY-py3.10/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/rest_api/routers/v1/agents.py", line 100, in create_agent
    return server.create_agent(agent, actor=actor)
  File "/Users/loaner/dev/MemGPT-fresh/letta/server/server.py", line 828, in create_agent
    raise ValueError("llm_config is required")
ValueError: llm_config is required
```

After:
```
curl --request POST \
  --url http://localhost:8283/v1/agents/ \
  --header 'Authorization: Bearer <token>' \
  --header 'Content-Type: application/json' \
  --data '{
  "memory_blocks": [
    {
      "value": "The human'\''s name is Bob the Builder",
      "label": "human"
    },
    {
      "label": "persona",
      "value": "My name is Sam, the all-knowing sentient AI."
    }
  ],
  "name": "agent_sam"
}'
{"detail":"llm_config is required"}%
```