### PR TITLE
ignore extra variables in env files

### DIFF
--- a/letta/settings.py
+++ b/letta/settings.py
@@ -17,7 +17,7 @@ class ToolSettings(BaseSettings):
 
 class ModelSettings(BaseSettings):
 
-    model_config = SettingsConfigDict(env_file='.env')
+    model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 
     # env_prefix='my_prefix_'
 
@@ -64,7 +64,7 @@ cors_origins = ["http://letta.localhost", "http://localhost:8283", "http://local
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="letta_")
+    model_config = SettingsConfigDict(env_prefix="letta_", extra='ignore')
 
     letta_dir: Optional[Path] = Field(Path.home() / ".letta", env="LETTA_DIR")
     debug: Optional[bool] = False
@@ -103,7 +103,7 @@ class Settings(BaseSettings):
 
 
 class TestSettings(Settings):
-    model_config = SettingsConfigDict(env_prefix="letta_test_")
+    model_config = SettingsConfigDict(env_prefix="letta_test_", extra='ignore')
 
     letta_dir: Optional[Path] = Field(Path.home() / ".letta/test", env="LETTA_TEST_DIR")
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
with v0.6.3, if you have extra variables in your .env file, letta fails to initiate because of the default behavior of [SettingsConfDict](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support).

**How to test**
Just try to import ChatMemory with extra variables in your `.env` file.

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/Letta/issues) or [PRs](https://github.com/cpacker/Letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
```
 |   File "/usr/local/lib/python3.12/site-packages/letta/settings.py", line 114, in <module>
gpt  |     model_settings = ModelSettings()
gpt  |                      ^^^^^^^^^^^^^^^
gpt  |   File "/usr/local/lib/python3.12/site-packages/pydantic_settings/main.py", line 167, in __init__
gpt  |     super().__init__(
gpt  |   File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
gpt  |     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
gpt  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gpt  | pydantic_core._pydantic_core.ValidationError: 18 validation errors for ModelSettings
gpt  | farsar_openai_api_key
gpt  |   Extra inputs are not permitted [type=extra_forbidden, input_value='sk-proj-osDZ-EC1p...BIKkifGyT40-OCcA', input_type=str]
gpt  |     For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden
```
