### PR TITLE
chore: set `Dockerfile` to use Python 3.12 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,36 @@
 # Start with pgvector base for builder
 FROM ankane/pgvector:v0.5.1 AS builder
 
-# Install Python and required packages
+# Install dependencies and Python 3.12
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-venv \
-    python3-pip \
-    python3-full \
+    wget \
     build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libgdbm-dev \
+    libdb5.3-dev \
+    libbz2-dev \
+    libexpat1-dev \
+    liblzma-dev \
+    libffi-dev \
     libpq-dev \
-    python3-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Download and install Python 3.12
+RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
+    && tar xzf Python-3.12.0.tgz \
+    && cd Python-3.12.0 \
+    && ./configure --enable-optimizations \
+    && make -j $(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.12.0 Python-3.12.0.tgz \
+    && ln -s /usr/local/bin/python3.12 /usr/local/bin/python3 \
+    && ln -s /usr/local/bin/pip3.12 /usr/local/bin/pip3
 
 ARG LETTA_ENVIRONMENT=PRODUCTION
 ENV LETTA_ENVIRONMENT=${LETTA_ENVIRONMENT} \
@@ -22,14 +42,15 @@ ENV LETTA_ENVIRONMENT=${LETTA_ENVIRONMENT} \
 WORKDIR /app
 
 # Create and activate virtual environment
-RUN python3 -m venv /opt/venv
+RUN python3.12 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Now install poetry in the virtual environment
-RUN pip install --no-cache-dir poetry==1.8.2
+# Install poetry in the virtual environment
+RUN pip3 install --no-cache-dir poetry==1.8.2
 
 # Copy dependency files first
 COPY pyproject.toml poetry.lock ./
+
 # Then copy the rest of the application code
 COPY . .
 
@@ -40,11 +61,34 @@ RUN poetry lock --no-update && \
 # Runtime stage
 FROM ankane/pgvector:v0.5.1 AS runtime
 
-# Install Python packages
+# Install Python 3.12 dependencies in runtime stage
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-venv \
-    && rm -rf /var/lib/apt/lists/* \
+    wget \
+    build-essential \
+    libssl-dev \
+    zlib1g-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libgdbm-dev \
+    libdb5.3-dev \
+    libbz2-dev \
+    libexpat1-dev \
+    liblzma-dev \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python 3.12 in runtime stage
+RUN wget https://www.python.org/ftp/python/3.12.0/Python-3.12.0.tgz \
+    && tar xzf Python-3.12.0.tgz \
+    && cd Python-3.12.0 \
+    && ./configure --enable-optimizations \
+    && make -j $(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-3.12.0 Python-3.12.0.tgz \
+    && ln -s /usr/local/bin/python3.12 /usr/local/bin/python3 \
     && mkdir -p /app
 
 ARG LETTA_ENVIRONMENT=PRODUCTION


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Our dependencies are not reliably installing because we aren't pinning a python/poetry version. 

**How to test**
Run `docker compose -f dev-compose.yaml up --build -d`

**Have you tested this PR?**
Yes

