### PR TITLE
feat: Catch composio errors and return informative errors in the endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/tools.py
+++ b/letta/server/rest_api/routers/v1/tools.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
 from composio.client.collections import ActionModel, AppModel
+from composio.client.enums.base import EnumStringNotFound
+from composio.exceptions import ComposioSDKError
 from fastapi import APIRouter, Body, Depends, Header, HTTPException
 
 from letta.errors import LettaToolCreateError
@@ -248,8 +250,6 @@ def add_composio_tool(
     """
     actor = server.get_user_or_default(user_id=user_id)
     composio_api_key = get_composio_key(server, actor=actor)
-    from composio.client.enums.base import EnumStringNotFound
-    from composio.exceptions import ComposioSDKError
 
     try:
         tool_create = ToolCreate.from_composio(action_name=composio_action_name, api_key=composio_api_key)


### PR DESCRIPTION
## Description

Catch composio errors and return informative errors in the endpoint. 

## Testing

Tested manually:

```
(base) mattzhou@Matts-MacBook-Pro ~ % curl -X POST http://localhost:8283/v1/tools/composio/BAMBOOHR_GETS_TABLE_ROWS_FOR_A_GIVEN_EMPLOYEE_AND_TABLE_COMBINATION | jq

{
  "detail": {
    "message": "No connected account found for tool `BAMBOOHR_GETS_TABLE_ROWS_FOR_A_GIVEN_EMPLOYEE_AND_TABLE_COMBINATION`. You need to connect the relevant app in Composio order to use the tool.",
    "composio_action_name": "BAMBOOHR_GETS_TABLE_ROWS_FOR_A_GIVEN_EMPLOYEE_AND_TABLE_COMBINATION"
  }
}
```

```
(base) mattzhou@Matts-MacBook-Pro ~ % curl -X POST http://localhost:8283/v1/tools/composio/oops | jq                                                           

{
  "detail": {
    "message": "Cannot find composio action with name `oops`.",
    "composio_action_name": "oops"
  }
}
```