### PR TITLE
fix: Changing e2b template id as an env var reflects immediately

### DIFF
--- a/letta/schemas/sandbox_config.py
+++ b/letta/schemas/sandbox_config.py
@@ -3,10 +3,11 @@ import json
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from letta.schemas.agent import AgentState
 from letta.schemas.letta_base import LettaBase, OrmMetadataBase
+from letta.settings import tool_settings
 
 
 # Sandbox Config
@@ -44,6 +45,16 @@ class E2BSandboxConfig(BaseModel):
     @property
     def type(self) -> "SandboxType":
         return SandboxType.E2B
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_template(cls, data: dict):
+        """
+        Assign a default template value if the template field is not provided.
+        """
+        if data.get("template") is None:
+            data["template"] = tool_settings.e2b_sandbox_template_id
+        return data
 
 
 class SandboxConfigBase(OrmMetadataBase):

--- a/letta/services/sandbox_config_manager.py
+++ b/letta/services/sandbox_config_manager.py
@@ -5,7 +5,7 @@ from letta.log import get_logger
 from letta.orm.errors import NoResultFound
 from letta.orm.sandbox_config import SandboxConfig as SandboxConfigModel
 from letta.orm.sandbox_config import SandboxEnvironmentVariable as SandboxEnvVarModel
-from letta.schemas.sandbox_config import E2BSandboxConfig, LocalSandboxConfig
+from letta.schemas.sandbox_config import LocalSandboxConfig
 from letta.schemas.sandbox_config import SandboxConfig as PydanticSandboxConfig
 from letta.schemas.sandbox_config import SandboxConfigCreate, SandboxConfigUpdate
 from letta.schemas.sandbox_config import SandboxEnvironmentVariable as PydanticEnvVar
@@ -27,7 +27,6 @@ class SandboxConfigManager:
         from letta.server.server import db_context
 
         self.session_maker = db_context
-        self.e2b_template_id = settings.e2b_sandbox_template_id
 
     @enforce_types
     def get_or_create_default_sandbox_config(self, sandbox_type: SandboxType, actor: PydanticUser) -> PydanticSandboxConfig:
@@ -37,8 +36,9 @@ class SandboxConfigManager:
 
             # TODO: Add more sandbox types later
             if sandbox_type == SandboxType.E2B:
-                default_config = E2BSandboxConfig(template=self.e2b_template_id).model_dump(exclude_none=True)
+                default_config = {}  # Empty
             else:
+                # TODO: May want to move this to environment variables v.s. persisting in database
                 default_local_sandbox_path = str(Path(__file__).parent / "tool_sandbox_env")
                 default_config = LocalSandboxConfig(sandbox_dir=default_local_sandbox_path).model_dump(exclude_none=True)
 


### PR DESCRIPTION
Changing e2b template id as an env var reflects immediately. Before, it needed to be re-written to the database, now it derives directly from the environment variable. Existing test cases for grabbing the default e2b covers this.