### PR TITLE
fix: propagate error on tool failure

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -10,6 +10,7 @@ from typing import List, Literal, Optional, Tuple, Union
 from letta.constants import (
     BASE_TOOLS,
     CLI_WARNING_PREFIX,
+    ERROR_MESSAGE_PREFIX,
     FIRST_MESSAGE_ATTEMPTS,
     FUNC_FAILED_HEARTBEAT_MESSAGE,
     IN_CONTEXT_MEMORY_KEYWORD,
@@ -863,7 +864,7 @@ class Agent(BaseAgent):
                 return messages, False, True  # force a heartbeat to allow agent to handle error
 
             # Step 4: check if function response is an error
-            if function_response_string.startswith("Error"):
+            if function_response_string.startswith(ERROR_MESSAGE_PREFIX):
                 function_response = package_function_response(False, function_response_string)
                 # TODO: truncate error message somehow
                 messages.append(

--- a/letta/agent.py
+++ b/letta/agent.py
@@ -839,7 +839,7 @@ class Agent(BaseAgent):
                 function_args.pop("self", None)
                 # error_msg = f"Error calling function {function_name} with args {function_args}: {str(e)}"
                 # Less detailed - don't provide full args, idea is that it should be in recent context so no need (just adds noise)
-                error_msg = f"Error calling function {function_name}: {str(e)}"
+                error_msg = get_friendly_error_msg(function_name=function_name, exception_name=type(e).__name__, exception_message=str(e))
                 error_msg_user = f"{error_msg}\n{traceback.format_exc()}"
                 printd(error_msg_user)
                 function_response = package_function_response(False, error_msg)
@@ -862,8 +862,29 @@ class Agent(BaseAgent):
                 self.interface.function_message(f"Error: {error_msg}", msg_obj=messages[-1])
                 return messages, False, True  # force a heartbeat to allow agent to handle error
 
+            # Step 4: check if function response is an error
+            if function_response_string.startswith("Error"):
+                function_response = package_function_response(False, function_response_string)
+                # TODO: truncate error message somehow
+                messages.append(
+                    Message.dict_to_message(
+                        agent_id=self.agent_state.id,
+                        user_id=self.agent_state.created_by_id,
+                        model=self.model,
+                        openai_message_dict={
+                            "role": "tool",
+                            "name": function_name,
+                            "content": function_response,
+                            "tool_call_id": tool_call_id,
+                        },
+                    )
+                )  # extend conversation with function response
+                self.interface.function_message(f"Ran {function_name}({function_args})", msg_obj=messages[-1])
+                self.interface.function_message(f"Error: {function_response_string}", msg_obj=messages[-1])
+                return messages, False, True  # force a heartbeat to allow agent to handle error
+
             # If no failures happened along the way: ...
-            # Step 4: send the info on the function call and function response to GPT
+            # Step 5: send the info on the function call and function response to GPT
             messages.append(
                 Message.dict_to_message(
                     agent_id=self.agent_state.id,

--- a/letta/constants.py
+++ b/letta/constants.py
@@ -69,6 +69,8 @@ INITIAL_BOOT_MESSAGE_SEND_MESSAGE_FIRST_MSG = STARTUP_QUOTES[2]
 
 CLI_WARNING_PREFIX = "Warning: "
 
+ERROR_MESSAGE_PREFIX = "Error"
+
 NON_USER_MSG_PREFIX = "[This is an automated system message hidden from the user] "
 
 # Constants to do with summarization / conversation length window

--- a/letta/server/rest_api/interface.py
+++ b/letta/server/rest_api/interface.py
@@ -238,7 +238,7 @@ class QueuingInterface(AgentInterface):
             new_message = {"function_return": msg, "status": "success"}
 
         elif msg.startswith("Error: "):
-            msg = msg.replace("Error: ", "", count=1)
+            msg = msg.replace("Error: ", "", 1)
             new_message = {"function_return": msg, "status": "error"}
 
         else:
@@ -951,7 +951,7 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
             )
 
         elif msg.startswith("Error: "):
-            msg = msg.replace("Error: ", "", count=1)
+            msg = msg.replace("Error: ", "", 1)
             # new_message = {"function_return": msg, "status": "error"}
             assert msg_obj.tool_call_id is not None
             new_message = ToolReturnMessage(

--- a/letta/server/rest_api/interface.py
+++ b/letta/server/rest_api/interface.py
@@ -238,7 +238,7 @@ class QueuingInterface(AgentInterface):
             new_message = {"function_return": msg, "status": "success"}
 
         elif msg.startswith("Error: "):
-            msg = msg.replace("Error: ", "")
+            msg = msg.replace("Error: ", "", count=1)
             new_message = {"function_return": msg, "status": "error"}
 
         else:
@@ -951,7 +951,7 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
             )
 
         elif msg.startswith("Error: "):
-            msg = msg.replace("Error: ", "")
+            msg = msg.replace("Error: ", "", count=1)
             # new_message = {"function_return": msg, "status": "error"}
             assert msg_obj.tool_call_id is not None
             new_message = ToolReturnMessage(

--- a/letta/utils.py
+++ b/letta/utils.py
@@ -28,6 +28,7 @@ from letta.constants import (
     CLI_WARNING_PREFIX,
     CORE_MEMORY_HUMAN_CHAR_LIMIT,
     CORE_MEMORY_PERSONA_CHAR_LIMIT,
+    ERROR_MESSAGE_PREFIX,
     LETTA_DIR,
     MAX_FILENAME_LENGTH,
     TOOL_CALL_ID_MAX_LEN,
@@ -1122,7 +1123,7 @@ def sanitize_filename(filename: str) -> str:
 def get_friendly_error_msg(function_name: str, exception_name: str, exception_message: str):
     from letta.constants import MAX_ERROR_MESSAGE_CHAR_LIMIT
 
-    error_msg = f"Error executing function {function_name}: {exception_name}: {exception_message}"
+    error_msg = f"{ERROR_MESSAGE_PREFIX} executing function {function_name}: {exception_name}: {exception_message}"
     if len(error_msg) > MAX_ERROR_MESSAGE_CHAR_LIMIT:
         error_msg = error_msg[:MAX_ERROR_MESSAGE_CHAR_LIMIT]
     return error_msg

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import threading
 import time
@@ -378,6 +379,39 @@ def test_function_return_limit(client: Union[LocalClient, RESTClient]):
     # assert (
     #     len(res_json["message"]) <= 1000 + padding
     # ), f"Expected length to be less than or equal to 1000 + {padding}, but got {len(res_json['message'])}"
+
+    client.delete_agent(agent_id=agent.id)
+
+
+def test_function_always_error(client: Union[LocalClient, RESTClient]):
+    """Test to see if function that errors works correctly"""
+
+    def always_error():
+        """
+        Always throw an error.
+        """
+        return 5/0
+
+    tool = client.create_or_update_tool(func=always_error)
+    agent = client.create_agent(tool_ids=[tool.id])
+    # get function response
+    response = client.send_message(agent_id=agent.id, message="call the always_error function", role="user")
+    print(response.messages)
+
+    response_message = None
+    for message in response.messages:
+        if isinstance(message, FunctionReturn):
+            response_message = message
+            break
+
+    assert response_message, "FunctionReturn message not found in response"
+    assert response_message.status == "error"
+    if isinstance(client, RESTClient):
+        assert response_message.function_return == "Error executing function always_error: ZeroDivisionError: division by zero"
+    else:
+        response_json = json.loads(response_message.function_return)
+        assert response_json['status'] == "Failed"
+        assert response_json['message'] == "Error executing function always_error: ZeroDivisionError: division by zero"
 
     client.delete_agent(agent_id=agent.id)
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
reinstate prior functionality. following up with a more robust implementation that doesn't infer status based on the string (but this is fine for now since I am setting the string the same way at all callsites)

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
poetry run pytest -s -vv tests/test_client.py::test_function_always_error

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
