### PR TITLE
Fix bug: add required argument `actor` (`load_file_to_source`).

### DIFF
--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2909,7 +2909,7 @@ class LocalClient(AbstractClient):
         job = self.server.job_manager.create_job(pydantic_job=job, actor=self.user)
 
         # TODO: implement blocking vs. non-blocking
-        self.server.load_file_to_source(source_id=source_id, file_path=filename, job_id=job.id)
+        self.server.load_file_to_source(source_id=source_id, file_path=filename, job_id=job.id, actor=self.user)
         return job
 
     def delete_file_from_source(self, source_id: str, file_id: str):


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Bugfix: add required argument `actor` for `load_file_to_source` method

**How to test**
```python
client = letta.create_client()
# create source, locate file path, ...etc
client.load_file_to_source(local_file_path, source_id)
```

**Have you tested this PR?**
Yes.
I ran into this error when running locally with `ollama` server.
After the fix, the error is gone.

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
NO.

**Additional context**
N/A
