### PR TITLE
fix: validate after limit assignment in `create_block`

### DIFF
--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -1048,9 +1048,10 @@ class RESTClient(AbstractClient):
     def create_block(
         self, label: str, value: str, limit: Optional[int] = None, template_name: Optional[str] = None, is_template: bool = False
     ) -> Block:  #
-        request = CreateBlock(label=label, value=value, template=is_template, template_name=template_name)
+        request_kwargs = dict(label=label, value=value, template=is_template, template_name=template_name)
         if limit:
-            request.limit = limit
+            request_kwargs['limit'] = limit
+        request = CreateBlock(**request_kwargs)
         response = requests.post(f"{self.base_url}/{self.api_prefix}/blocks", json=request.model_dump(), headers=self.headers)
         if response.status_code != 200:
             raise ValueError(f"Failed to create block: {response.text}")


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
While creating a block [here](https://github.com/letta-ai/letta/blob/69e376406ec8b0368eb02baa12308c8a4d142c4e/letta/client/client.py#L1051), the limit is assigned later which leads to the pydantic validator [here](https://github.com/letta-ai/letta/blob/ea2a7395f4023f5b9fab03e6273db3b64a1181d5/letta/schemas/block.py#L38) failing with exception as it validates against the default limit of 5000 instead of what is being passed by the arguments.

<img width="1465" alt="Screenshot 2024-12-23 at 2 32 59 AM" src="https://github.com/user-attachments/assets/aaa6c237-5edd-4b6b-99e6-ff46020a8929" />

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
