### PR TITLE
fix: update authorization header to use X-BARE-PASSWORD format

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -17,7 +17,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - uses: actions/checkout@v3
-    
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
@@ -38,4 +38,3 @@ jobs:
           letta/letta:latest
           memgpt/letta:${{ env.CURRENT_VERSION }}
           memgpt/letta:latest
-          

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -428,7 +428,7 @@ class RESTClient(AbstractClient):
         super().__init__(debug=debug)
         self.base_url = base_url
         self.api_prefix = api_prefix
-        self.headers = {"accept": "application/json", "authorization": f"Bearer {token}"}
+        self.headers = {"accept": "application/json", "X-BARE-PASSWORD": f"password {token}"}
         if headers:
             self.headers.update(headers)
         self._default_llm_config = default_llm_config

--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -408,7 +408,8 @@ class RESTClient(AbstractClient):
     def __init__(
         self,
         base_url: str,
-        token: str,
+        token: Optional[str] = None,
+        password: Optional[str] = None,
         api_prefix: str = "v1",
         debug: bool = False,
         default_llm_config: Optional[LLMConfig] = None,
@@ -424,11 +425,18 @@ class RESTClient(AbstractClient):
             default_llm_config (Optional[LLMConfig]): The default LLM configuration.
             default_embedding_config (Optional[EmbeddingConfig]): The default embedding configuration.
             headers (Optional[Dict]): The additional headers for the REST API.
+            token (Optional[str]): The token for the REST API when using managed letta service.
+            password (Optional[str]): The password for the REST API when using self hosted letta service.
         """
         super().__init__(debug=debug)
         self.base_url = base_url
         self.api_prefix = api_prefix
-        self.headers = {"accept": "application/json", "X-BARE-PASSWORD": f"password {token}"}
+        if token:
+            self.headers = {"accept": "application/json", "Authorization": f"Bearer {token}"}
+        elif password:
+            self.headers = {"accept": "application/json", "X-BARE-PASSWORD": f"password {password}"}
+        else:
+            raise ValueError("Either token or password must be provided")
         if headers:
             self.headers.update(headers)
         self._default_llm_config = default_llm_config

--- a/letta/functions/schema_generator.py
+++ b/letta/functions/schema_generator.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
 
 from docstring_parser import parse
 from pydantic import BaseModel
-from pydantic.v1 import BaseModel as V1BaseModel
 
 
 def is_optional(annotation):

--- a/tests/test_tool_sandbox/restaurant_management_system/adjust_menu_prices.py
+++ b/tests/test_tool_sandbox/restaurant_management_system/adjust_menu_prices.py
@@ -8,7 +8,6 @@ def adjust_menu_prices(percentage: float) -> str:
         str: A formatted string summarizing the price adjustments.
     """
     import cowsay
-
     from core.menu import Menu, MenuItem  # Import a class from the codebase
     from core.utils import format_currency  # Use a utility function to test imports
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fixes a bug in Python SDK. Setting `token=<password>` when instantiating a RESTClient was not sufficient to authorize since `CheckPasswordMiddleware` was checking for `X-BARE-PASSWORD` instead of 'Authorization` header.

RESTClient is now setting `X-BARE-PASSWORD="password <password>` as a header.

**How to test**
```python
from letta.client.client import RESTClient

client = RESTClient(base_url="http://0.0.0.0:8283", token="<password>")
print(client.personas())
```
