### PR TITLE
chore: cleanup catching non-existent return value (#2202)

### DIFF
--- a/letta/server/rest_api/routers/v1/users.py
+++ b/letta/server/rest_api/routers/v1/users.py
@@ -23,7 +23,7 @@ def list_users(
     Get a list of all users in the database
     """
     try:
-        next_cursor, users = server.user_manager.list_users(cursor=cursor, limit=limit)
+        users = server.user_manager.list_users(cursor=cursor, limit=limit)
     except HTTPException:
         raise
     except Exception as e:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fixes issue #2202. The user_manager.list_users returns the combined user list, without next cursor. This patch cleans up the code to not capture non-existent return value and thus fixes the listing of users.
 
**How to test**

Listing users will succeed.

**Have you tested this PR?**

Tested by running the server locally and using curl to get the users.  Here is the relevant snippet:
```
curl -X GET -L "http://127.0.0.1:8283/v1/admin/users"
[{"id":"user-00000000-0000-4000-8000-000000000000","organization_id":"org-00000000-0000-4000-8000-000000000000","name":"default_user",......
```

**Related issues or PRs**

#2202 

**Is your PR over 500 lines of code?**
N/A

**Additional context**
A future TODO (if needed) is to add tests for list users. At the moment due to https://github.com/letta-ai/letta/commit/7ad5f013f37d8aeab5a9ea9e1c810938c7e7b857 the test are broken (gives ModuleNotFoundError: No module named 'openai').