### PR TITLE
docs(contrib): replace poetry shell with env activate for 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ First, install Poetry using [the official instructions here](https://python-poet
 Once Poetry is installed, navigate to the letta directory and install the Letta project with Poetry:
 ```shell
 cd letta
-poetry shell
+eval $(poetry env activate)
 poetry install --all-extras
 ```
 #### Setup PostgreSQL environment (optional)
@@ -60,8 +60,8 @@ alembic upgrade head
 Now when you want to use `letta`, make sure you first activate the `poetry` environment using poetry shell:
 
 ```shell
-$ poetry shell
-(pyletta-py3.12) $ letta run
+$ eval $(poetry env activate)
+(letta-py3.12) $ letta run
 ```
 
 Alternatively, you can use `poetry run` (which will activate the `poetry` environment for the `letta run` command only):


### PR DESCRIPTION
In poetry 2.0 [1] the the shell command has been removed and same functionality can be provided by env command [2].

1. https://python-poetry.org/blog/announcing-poetry-2.0.0
2. https://python-poetry.org/docs/managing-environments

**Please describe the purpose of this pull request.**
Fixes documentation to work with poetry 2.0.

**How to test**

Can be tested by running the updated steps manually.

**Have you tested this PR?**

Manually tested the updated instructions.

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
N/A 

**Additional context**
N/A