### PR TITLE
fix: avoid unnecessary database operations for non-server cli commands

### DIFF
--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -361,4 +361,4 @@ def delete_agent(
 def version() -> str:
     import letta
 
-    return letta.__version__
+    print(letta.__version__)

--- a/letta/cli/cli.py
+++ b/letta/cli/cli.py
@@ -15,7 +15,6 @@ from letta.local_llm.constants import ASSISTANT_MESSAGE_CLI_SYMBOL
 from letta.log import get_logger
 from letta.schemas.enums import OptionState
 from letta.schemas.memory import ChatMemory, Memory
-from letta.server.server import logger as server_logger
 
 # from letta.interface import CLIInterface as interface  # for printing to terminal
 from letta.streaming_interface import StreamingRefreshCLIInterface as interface  # for printing to terminal
@@ -118,6 +117,8 @@ def run(
     # TODO: remove Utils Debug after global logging is complete.
     utils.DEBUG = debug
     # TODO: add logging command line options for runtime log level
+
+    from letta.server.server import logger as server_logger
 
     if debug:
         logger.setLevel(logging.DEBUG)

--- a/letta/server/rest_api/routers/v1/health.py
+++ b/letta/server/rest_api/routers/v1/health.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
 
-from letta.cli.cli import version
+from letta import __version__
 from letta.schemas.health import Health
 
 if TYPE_CHECKING:
@@ -15,6 +15,6 @@ router = APIRouter(prefix="/health", tags=["health"])
 @router.get("/", response_model=Health, operation_id="health_check")
 def health_check():
     return Health(
-        version=version(),
+        version=__version__,
         status="ok",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import sys
 
@@ -74,3 +75,16 @@ def test_letta_run_create_new_agent(swap_letta_config):
     # Count occurrences of assistant messages
     robot = full_output.count(ASSISTANT_MESSAGE_CLI_SYMBOL)
     assert robot == 1, f"It appears that there are multiple instances of assistant messages outputted."
+
+
+def test_letta_version_prints_only_version(swap_letta_config):
+    # Start the letta version command
+    output = pexpect.run("poetry run letta version", encoding="utf-8")
+
+    # Remove ANSI escape sequences and whitespace
+    output = re.sub(r"\x1b\[[0-9;]*[mK]", "", output).strip()
+
+    from letta import __version__
+
+    # Get the full output and verify it contains only the version
+    assert output == __version__, f"Expected only '{__version__}', but got '{repr(output)}'"


### PR DESCRIPTION
Avoid unnecessary database operations while running non-server commands like `letta version`, `letta benchmark`, etc.

`letta version` has been fixed as well, it prints out `Creating engine` and no version before this PR.

**How to test**

A test case has been added to ensure that `letta version` prints out version number and nothing else.

For manual validation run:
- `letta version` should show prints out the version
- `poetry run pytest -v tests/test_cli.py -k test_letta_version_prints_only_version` should pass
- and definitely all other existing tests

**Have you tested this PR?**

```
root@42a43c02:/app# poetry run pytest -v tests/test_cli.py -k test_letta_version_prints_only_version
=========================================================================================================================================================================== test session starts ============================================================================================================================================================================
platform linux -- Python 3.11.2, pytest-8.3.4, pluggy-1.5.0 -- /app/.venv/bin/python
cachedir: .pytest_cache
rootdir: /app/tests
configfile: pytest.ini
plugins: asyncio-0.23.8, anyio-4.8.0, order-1.3.0, mock-3.14.0, langsmith-0.3.1
asyncio: mode=Mode.AUTO
collected 2 items / 1 deselected / 1 selected

tests/test_cli.py::test_letta_version_prints_only_version PASSED
```

