### PR TITLE
Change Azure Context Length

### DIFF
--- a/letta/llm_api/azure_openai_constants.py
+++ b/letta/llm_api/azure_openai_constants.py
@@ -6,5 +6,5 @@ AZURE_MODEL_TO_CONTEXT_LENGTH = {
     "gpt-35-turbo-0125": 16385,
     "gpt-4-0613": 8192,
     "gpt-4o-mini-2024-07-18": 128000,
-    "gpt-4o-2024-08-06": 128000,
+    "gpt-4o": 128000,
 }


### PR DESCRIPTION
Deployment of 4o ignores version.

**Please describe the purpose of this pull request.**
Fixes bug where azure openai does not have the correct context length for 4o versions.

**How to test**
Standard usage.

**Have you tested this PR?**
Yes, it successfully displays the proper context window.
![image](https://github.com/user-attachments/assets/2ac9adb3-b440-4f4a-8919-60bba3846300)


**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
No

**Additional context**
N/A
