### PR TITLE
fix: Google embeddings endpoint bug (#2416)

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -260,6 +260,7 @@ class Agent(BaseAgent):
         error_msg: str,
         tool_call_id: str,
         function_name: str,
+        function_args: str,
         function_response: str,
         messages: List[Message],
         include_function_failed_message: bool = False,
@@ -543,7 +544,7 @@ class Agent(BaseAgent):
             if function_response_string.startswith(ERROR_MESSAGE_PREFIX):
                 error_msg = function_response_string
                 messages = self._handle_function_error_response(
-                    error_msg, tool_call_id, function_name, function_response, messages, include_function_failed_message=True
+                    error_msg, tool_call_id, function_name, function_args, function_response, messages, include_function_failed_message=True
                 )
                 return messages, False, True  # force a heartbeat to allow agent to handle error
 

--- a/letta/settings.py
+++ b/letta/settings.py
@@ -85,7 +85,7 @@ class ModelSettings(BaseSettings):
 
     # google ai
     gemini_api_key: Optional[str] = None
-
+    gemini_base_url: str = "https://generativelanguage.googleapis.com/"
     # together
     together_api_key: Optional[str] = None
 

--- a/tests/test_base_functions.py
+++ b/tests/test_base_functions.py
@@ -180,7 +180,9 @@ def test_send_message_to_agent(client, agent_obj, other_agent_obj):
             found = True
             break
 
-    print(f"In context messages of the sender agent (without system):\n\n{"\n".join([m.text for m in in_context_messages[1:]])}")
+    # Compute the joined string first
+    joined_messages = "\n".join([m.text for m in in_context_messages[1:]])
+    print(f"In context messages of the sender agent (without system):\n\n{joined_messages}")
     if not found:
         raise Exception(f"Was not able to find an instance of the target snippet: {target_snippet}")
 

--- a/tests/test_google_embeddings.py
+++ b/tests/test_google_embeddings.py
@@ -1,0 +1,157 @@
+import pytest
+import httpx
+
+from letta.embeddings import GoogleEmbeddings  # Adjust the import based on your module structure
+from dotenv import load_dotenv
+
+load_dotenv()
+import os
+
+import pytest
+
+import time
+import uuid
+import pytest
+from letta_client import CreateBlock
+from letta_client import Letta as LettaSDKClient
+from letta_client import MessageCreate
+import threading
+
+SERVER_PORT = 8283
+
+
+def run_server():
+    load_dotenv()
+
+    from letta.server.rest_api.app import start_server
+
+    print("Starting server...")
+    start_server(debug=True)
+
+
+@pytest.fixture(scope="module")
+def client() -> LettaSDKClient:
+    # Get URL from environment or start server
+    server_url = os.getenv("LETTA_SERVER_URL", f"http://localhost:{SERVER_PORT}")
+    if not os.getenv("LETTA_SERVER_URL"):
+        print("Starting server thread")
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+        time.sleep(5)
+    print("Running client tests with server:", server_url)
+    client = LettaSDKClient(base_url=server_url, token=None)
+    yield client
+
+
+def test_google_embeddings_response():
+    api_key = os.environ.get("GEMINI_API_KEY")
+    model = "text-embedding-004"
+    base_url = "https://generativelanguage.googleapis.com"
+    text = "Hello, world!"
+
+    embedding_model = GoogleEmbeddings(api_key, model, base_url)
+    response = None
+
+    try:
+        response = embedding_model.get_text_embedding(text)
+    except httpx.HTTPStatusError as e:
+        pytest.fail(f"Request failed with status code {e.response.status_code}")
+
+    assert response is not None, "No response received from API"
+    assert isinstance(response, list), "Response is not a list of embeddings"
+
+
+def test_archival_insert_text_embedding_004(client: LettaSDKClient):
+    """
+    Test that an agent with model 'gemini-2.0-flash-exp' and embedding 'text_embedding_004'
+    correctly inserts a message into its archival memory.
+
+    The test works by:
+      1. Creating an agent with the desired model and embedding.
+      2. Sending a message prefixed with 'archive :' to instruct the agent to store the message in archival.
+      3. Retrieving the archival memory via the agent messaging API.
+      4. Verifying that the archival message is stored.
+    """
+    # Create an agent with the specified model and embedding.
+    agent = client.agents.create(
+        name=f"archival_insert_text_embedding_004",
+        memory_blocks=[
+            CreateBlock(label="human", value="name: archival_test"),
+            CreateBlock(label="persona", value="You are a helpful assistant that loves helping out the user"),
+        ],
+        model="google_ai/gemini-2.0-flash-exp",
+        embedding="google_ai/text-embedding-004",
+    )
+
+    # Define the archival message.
+    archival_message = "Archival insertion test message"
+
+    # Send a message instructing the agent to archive it.
+    res = client.agents.messages.create(
+        agent_id=agent.id,
+        messages=[MessageCreate(role="user", content=f"Store this in your archive memory: {archival_message}")],
+    )
+    print(res.messages)
+
+
+    # Retrieve the archival messages through the agent messaging API.
+    archived_messages = client.agents.messages.create(
+        agent_id=agent.id,
+        messages=[MessageCreate(role="user", content=f"retrieve from archival memory : {archival_message}")],
+    )
+
+    print(archived_messages.messages)
+    # Assert that the archival message is present.
+    assert (
+        any(message.status == "success" for message in archived_messages.messages if message.message_type == "tool_return_message")
+    ), f"Archival message '{archival_message}' not found. Archived messages: {archived_messages}"
+
+    # Cleanup: Delete the agent.
+    client.agents.delete(agent.id)
+
+
+def test_archival_insert_embedding_001(client: LettaSDKClient):
+    """
+    Test that an agent with model 'gemini-2.0-flash-exp' and embedding 'embedding_001'
+    correctly inserts a message into its archival memory.
+
+    The test works by:
+      1. Creating an agent with the desired model and embedding.
+      2. Sending a message prefixed with 'archive :' to instruct the agent to store the message in archival.
+      3. Retrieving the archival memory via the agent messaging API.
+      4. Verifying that the archival message is stored.
+    """
+    # Create an agent with the specified model and embedding.
+    agent = client.agents.create(
+        name=f"archival_insert_embedding_001",
+        memory_blocks=[
+            CreateBlock(label="human", value="name: archival_test"),
+            CreateBlock(label="persona", value="You are a helpful assistant that loves helping out the user"),
+        ],
+        model="google_ai/gemini-2.0-flash-exp",
+        embedding="google_ai/embedding-001",
+    )
+
+    # Define the archival message.
+    archival_message = "Archival insertion test message"
+
+    # Send a message instructing the agent to archive it.
+    client.agents.messages.create(
+        agent_id=agent.id,
+        messages=[MessageCreate(role="user", content=f"archive : {archival_message}")],
+    )
+
+
+    # Retrieve the archival messages through the agent messaging API.
+    archived_messages = client.agents.messages.create(
+        agent_id=agent.id,
+        messages=[MessageCreate(role="user", content=f"retrieve from archival memory : {archival_message}")],
+    )
+
+    # Assert that the archival message is present.
+    assert(
+        any(message.status == "success" for message in archived_messages.messages if message.message_type == "tool_return_message")
+    ), f"Archival message '{archival_message}' not found. Archived messages: {archived_messages}"
+
+    # Cleanup: Delete the agent.
+    client.agents.delete(agent.id)

--- a/tests/test_sdk_client.py
+++ b/tests/test_sdk_client.py
@@ -117,7 +117,7 @@ def test_shared_blocks(client: LettaSDKClient):
     )
     assert (
         "charles" in client.agents.core_memory.retrieve_block(agent_id=agent_state2.id, block_label="human").value.lower()
-    ), f"Shared block update failed {client.agents.core_memory.retrieve_block(agent_id=agent_state2.id, block_label="human").value}"
+    ), f"Shared block update failed {client.agents.core_memory.retrieve_block(agent_id=agent_state2.id, block_label='human').value}"
 
     # cleanup
     client.agents.delete(agent_state1.id)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This is a fix for the archival tools not working when using Google Gemini's embedding models - text-embedding-004 and embedding-001. Also fixed a few syntax errors in tests/test_base_function and tests/test_sdk_client that did not let me run pytest.

**How to test**
Command to run the test: `poetry run pytest tests/test_google_embeddings`
There are 3 test cases, 
  - checks validity of the gemini api endpoint
  - an archival insert and retrieval for the text-embedding-004 embedding model
  - an archival insert and retrieval for the embedding-001 embedding model

**Have you tested this PR?**
Pytest
```
PS E:\projects\open_source\letta> poetry run pytest .\tests\test_google_embeddings.py
================================================= test session starts =================================================
platform win32 -- Python 3.11.0, pytest-8.3.4, pluggy-1.5.0
rootdir: E:\projects\open_source\letta\tests
configfile: pytest.ini
plugins: anyio-4.8.0, langsmith-0.3.6, asyncio-0.23.8, mock-3.14.0, order-1.3.0
asyncio: mode=Mode.AUTO
collected 3 items

tests\test_google_embeddings.py ... 
====================================== 3 passed, 14 warnings in 87.65s (0:01:27) ======================================
```
text-embedding-004 archival output
![image](https://github.com/user-attachments/assets/6a3023bc-6983-4faf-aace-bb32f0c069a0)

embedding-001 archival output
![image](https://github.com/user-attachments/assets/596c8cda-91b8-491a-acc7-2773c9d48d9c)

**Related issues or PRs**
This is a fix intended for this issue [#2416)](https://github.com/letta-ai/letta/issues/2416) 

**Is your PR over 500 lines of code?**
No, 194 additions and 4 deletions.

**Additional context**
Add any other context or screenshots about the PR here.
