### PR TITLE
fix: remove the missing arg `name` from create_tool in client.py

### DIFF
--- a/letta/client/client.py
+++ b/letta/client/client.py
@@ -2968,7 +2968,6 @@ class LocalClient(AbstractClient):
 
         Args:
             func (callable): The function to create a tool for.
-            name: (str): Name of the tool (must be unique per-user.)
             tags (Optional[List[str]], optional): Tags for the tool. Defaults to None.
             description (str, optional): The description.
             return_char_limit (int): The character limit for the tool's return value. Defaults to FUNCTION_RETURN_CHAR_LIMIT.
@@ -2981,6 +2980,7 @@ class LocalClient(AbstractClient):
         # parse source code/schema
         source_code = parse_source_code(func)
         source_type = "python"
+        name = func.__name__  # Initialize name using function's __name__
         if not tags:
             tags = []
 


### PR DESCRIPTION
his commit modifies the create_tool method to automatically derive the name of the tool from the function's __name__ attribute instead of requiring it as a parameter.

**Please describe the purpose of this pull request.**
 The purpose of this pull request is to fix a bug. The bug occurred because the name variable was missing in the function signature of the create_tool method. The fix automatically derives the tool's name from the function's __name__ attribute, removing the need for it as a separate parameter.

**How to test**
Yes, this fix has been tested locally with a few functions and the tool names are set correctly. However, the testing wasn’t extensive. Please check the solution and let me know if the function still needs the `name` parameter or if this fix works.

**Have you tested this PR?**
N/A

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
No, this PR changes 2 lines of code. 

**Additional context**
N/A
