### PR TITLE
feat: add type resolution support for complex types

### DIFF
--- a/letta/functions/ast_parsers.py
+++ b/letta/functions/ast_parsers.py
@@ -32,6 +32,19 @@ def resolve_type(annotation: str):
         return BUILTIN_TYPES[annotation]
 
     try:
+        if annotation.startswith("list["):
+            inner_type = annotation[len("list[") : -1]
+            resolved_type = resolve_type(inner_type)
+            return list
+        elif annotation.startswith("dict["):
+            inner_types = annotation[len("dict[") : -1]
+            key_type, value_type = inner_types.split(",")
+            return dict
+        elif annotation.startswith("tuple["):
+            inner_types = annotation[len("tuple[") : -1]
+            type_list = [resolve_type(t.strip()) for t in inner_types.split(",")]
+            return tuple
+
         parsed = ast.literal_eval(annotation)
         if isinstance(parsed, type):
             return parsed

--- a/tests/test_ast_parsing.py
+++ b/tests/test_ast_parsing.py
@@ -214,3 +214,62 @@ def test_coerce_dict_args_non_parseable_list_or_dict():
 
     with pytest.raises(ValueError, match="Failed to coerce argument 'bad_list' to list"):
         coerce_dict_args_by_annotations(function_args, annotations)
+
+
+def test_coerce_dict_args_with_complex_list_annotation():
+    """
+    Test coercion when list with type annotation (e.g., list[int]) is used.
+    """
+    annotations = {"a": "list[int]"}
+    function_args = {"a": "[1, 2, 3]"}
+
+    coerced_args = coerce_dict_args_by_annotations(function_args, annotations)
+    assert coerced_args["a"] == [1, 2, 3]
+
+
+def test_coerce_dict_args_with_complex_dict_annotation():
+    """
+    Test coercion when dict with type annotation (e.g., dict[str, int]) is used.
+    """
+    annotations = {"a": "dict[str, int]"}
+    function_args = {"a": '{"x": 1, "y": 2}'}
+
+    coerced_args = coerce_dict_args_by_annotations(function_args, annotations)
+    assert coerced_args["a"] == {"x": 1, "y": 2}
+
+
+def test_coerce_dict_args_unsupported_complex_annotation():
+    """
+    If an unsupported complex annotation is used (e.g., a custom class),
+    a ValueError should be raised.
+    """
+    annotations = {"f": "CustomClass[int]"}
+    function_args = {"f": "CustomClass(42)"}
+
+    with pytest.raises(ValueError, match="Failed to coerce argument 'f' to CustomClass\[int\]: Unsupported annotation: CustomClass\[int\]"):
+        coerce_dict_args_by_annotations(function_args, annotations)
+
+
+def test_coerce_dict_args_with_nested_complex_annotation():
+    """
+    Test coercion with complex nested types like list[dict[str, int]].
+    """
+    annotations = {"a": "list[dict[str, int]]"}
+    function_args = {"a": '[{"x": 1}, {"y": 2}]'}
+
+    coerced_args = coerce_dict_args_by_annotations(function_args, annotations)
+    assert coerced_args["a"] == [{"x": 1}, {"y": 2}]
+
+
+def test_coerce_dict_args_with_default_arguments():
+    """
+    Test coercion with default arguments, where some arguments have defaults in the source code.
+    """
+    annotations = {"a": "int", "b": "str"}
+    function_args = {"a": "42"}
+
+    function_args.setdefault("b", "hello")  # Setting the default value for 'b'
+
+    coerced_args = coerce_dict_args_by_annotations(function_args, annotations)
+    assert coerced_args["a"] == 42
+    assert coerced_args["b"] == "hello"


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This pull request adds support for complex type annotations in the `resolve_type` function and expands the test suite to cover these new cases.

Improvements to type resolution:

* [`letta/functions/ast_parsers.py`](diffhunk://#diff-fa9fad0367a76d5bad51009abe63fad360fb4f73509a12301c55f78c05634f03R35-R47): Revised the `resolve_type` function to handle complex type annotations such as `list`, `dict`, and `tuple`.

Improvements to testing:

* [`tests/test_ast_parsing.py`](diffhunk://#diff-86328b8b0e36762354f12f478afaf5bffe35edf920403dbf5c0dbdc3b47a78c1R217-R275): Added multiple test cases to ensure correct coercion of arguments with complex type annotations, including `list[int]`, `dict[str, int]`, nested types like `list[dict[str, int]]`, and handling of unsupported complex annotations.

**How to test**
`poetry run pytest tests/test_ast_parsing.py`

**Have you tested this PR?**
20 test cases passed.

**Related issues or PRs**
resolves #2430
