### PR TITLE
fix: Use right tag for debug messages

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -454,7 +454,7 @@ class Agent(BaseAgent):
                     openai_message_dict=response_message.model_dump(),
                 )
             )  # extend conversation with assistant's reply
-            self.logger.info(f"Function call message: {messages[-1]}")
+            self.logger.debug(f"Function call message: {messages[-1]}")
 
             nonnull_content = False
             if response_message.content:
@@ -469,7 +469,7 @@ class Agent(BaseAgent):
                 response_message.function_call if response_message.function_call is not None else response_message.tool_calls[0].function
             )
             function_name = function_call.name
-            self.logger.info(f"Request to call function {function_name} with tool_call_id: {tool_call_id}")
+            self.logger.debug(f"Request to call function {function_name} with tool_call_id: {tool_call_id}")
 
             # Failure case 1: function name is wrong (not in agent_state.tools)
             target_letta_tool = None


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fixes the tags for debug messages (info => debug)

**How to test**
Tested that log messages are not showing up during regular run.

**Have you tested this PR?**
Tested with manual run to check that messages are not coming. 

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
N/A

**Additional context**
N/A