### PR TITLE
feat: Add model to context length mapping for gpt-4o-mini

### DIFF
--- a/letta/llm_api/azure_openai_constants.py
+++ b/letta/llm_api/azure_openai_constants.py
@@ -6,5 +6,6 @@ AZURE_MODEL_TO_CONTEXT_LENGTH = {
     "gpt-35-turbo-0125": 16385,
     "gpt-4-0613": 8192,
     "gpt-4o-mini-2024-07-18": 128000,
+    "gpt-4o-mini": 128000,
     "gpt-4o": 128000,
 }


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Adds support for gpt-4o-mini model in the context length conversion of Azure OpenAI code.

**How to test**
When deploying the gpt-4o-mini on Azure, the agent would pick invalid context length. With this change you can deploy and test against gpt-4o-mini.

**Have you tested this PR?**
Tested manually by deploying gpt-4o-mini with Azure OpenAI.

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
N/A

**Additional context**
N/A