### PR TITLE
fix(load-directory): Fix up file extension comparison & path list construction

### DIFF
--- a/letta/cli/cli_load.py
+++ b/letta/cli/cli_load.py
@@ -20,7 +20,7 @@ from letta.data_sources.connectors import DirectoryConnector
 app = typer.Typer()
 
 
-default_extensions = ".txt,.md,.pdf"
+default_extensions = "txt,md,pdf"
 
 
 @app.command("directory")

--- a/letta/data_sources/connectors_helper.py
+++ b/letta/data_sources/connectors_helper.py
@@ -73,7 +73,7 @@ def get_filenames_in_dir(
             ext = file_path.suffix.lstrip(".")
             # If required_exts is empty, match any file
             if not required_exts or ext in required_exts:
-                files.append(file_path)
+                files.append(str(file_path))
 
     return files
 


### PR DESCRIPTION
The file extensions used in `cli_load.py` has '.' prefix. The comparison in `get_filenames_in_dir` uses the strings from
`ext = file_path.suffix.lstrip(".")` resulting in strings without '.' prefix. We fix this by giving extensions without '.' prefix in the default list of extensions to compare against.

The file_path generated are of type PosixPath, whereas string list is expected. We fix this by converting PosixPath to string before constructing the list.

**Please describe the purpose of this pull request.**
Bug fix in the code path when using load directory.

**How to test**/**Have you tested this PR?**

Manually running a load directory will fail in HEAD when pointed to a directory:

```letta load directory --input-dir <dir path> --name <name>```

will fail to load the text file due to the mismatch of extensions. When that is fixed (as given in the patch) the next failure seen will be that PosixPath is used instead. After applying the patch the files from directory could be loaded and embedding generated. Tested this with Azure as the provider.

**Related issues or PRs**
N/A

**Is your PR over 500 lines of code?**
N/A

**Additional context**
N/A