### PR TITLE
Update example.py with docstring note about `letta_client`

### DIFF
--- a/examples/docs/example.py
+++ b/examples/docs/example.py
@@ -8,6 +8,7 @@ If you're using Letta Cloud, replace 'baseURL' with 'token'
 See: https://docs.letta.com/api-reference/overview
 
 Execute this script using `poetry run python3 example.py`
+This will install `letta_client` and other dependencies.
 """
 client = Letta(
     base_url="http://localhost:8283",


### PR DESCRIPTION
Adds clarifying note about `letta_client` -- I was a bit confused with `pip install letta` / `pip install letta_client` while going through this, maybe helpful to others as well.