### PR TITLE
[FIX] Update example.py to reflect breaking API changes

### DIFF
--- a/examples/docs/example.py
+++ b/examples/docs/example.py
@@ -77,8 +77,8 @@ agent_copy = client.agents.create(
     model="openai/gpt-4o-mini",
     embedding="openai/text-embedding-ada-002",
 )
-block = client.agents.core_memory.retrieve_block(agent.id, "human")
-agent_copy = client.agents.core_memory.attach_block(agent_copy.id, block.id)
+block = client.agents.blocks.retrieve(agent.id, "human")
+agent_copy = client.agents.blocks.attach(agent_copy.id, block.id)
 
 print(f"Created agent copy with shared memory named {agent_copy.name}")
 
@@ -95,7 +95,7 @@ response = client.agents.messages.create(
 
 print(f"Sent message to agent {agent_copy.name}: {message_text}")
 
-block = client.agents.core_memory.retrieve_block(agent_copy.id, "human")
+block = client.agents.blocks.retrieve(agent_copy.id, "human")
 print(f"New core memory for agent {agent_copy.name}: {block.value}")
 
 message_text = "What's my name?"


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
For the letta-client python SDK, retrieving and attaching core memory blocks are no longer under core_memory, but under blocks. 

Basically solving this issue:

```
(letta) kyuds@kyuds docs % poetry run python3 example.py
Created agent with name ThoughtfulParakeet
Sent message to agent ThoughtfulParakeet: What's my name?
Agent thoughts: User just logged in and asked for their name. I need to respond with the name I have stored in memory.
Agent response: Your name is Caren. Nice to meet you!
Created tool secret_message and attached to agent ThoughtfulParakeet
Sent message to agent ThoughtfulParakeet: Run secret message tool and tell me what it returns
Agent thoughts: User requested to run the secret message tool. I need to see what it returns and report back.
Tool call information: name='secret_message' arguments='{\n  "request_heartbeat": true\n}' tool_call_id='call_5MwJMcOzqizL8HfuMmvmgVus'
Tool response information: success
Agent thoughts: Received the secret message output. Time to share it with the user.
Agent response: The secret message tool returned: "Hello world!"
Traceback (most recent call last):
  File "/Users/kyuds/dev/letta/examples/docs/example.py", line 80, in <module>
    block = client.agents.core_memory.retrieve_block(agent.id, "human")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'CoreMemoryClient' object has no attribute 'retrieve_block'
```

**How to test**
I only updated the example code

