### PR TITLE
fix: Spurious empty chunk warning on Claude

### DIFF
--- a/letta/server/rest_api/interface.py
+++ b/letta/server/rest_api/interface.py
@@ -918,13 +918,9 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
             # skip if there's a finish
             return None
         else:
-            # Example case that would trigger here:
-            # id='chatcmpl-AKtUvREgRRvgTW6n8ZafiKuV0mxhQ'
-            # choices=[ChunkChoice(finish_reason=None, index=0, delta=MessageDelta(content=None, tool_calls=None, function_call=None), logprobs=None)]
-            # created=datetime.datetime(2024, 10, 21, 20, 40, 57, tzinfo=TzInfo(UTC))
-            # model='gpt-4o-mini-2024-07-18'
-            # object='chat.completion.chunk'
-            warnings.warn(f"Couldn't find delta in chunk: {chunk}")
+            # Only warn for non-Claude models since Claude commonly has empty first chunks
+            if not chunk.model.startswith("claude-"):
+                warnings.warn(f"Couldn't find delta in chunk: {chunk}")
             return None
 
         return processed_chunk

--- a/letta/server/rest_api/interface.py
+++ b/letta/server/rest_api/interface.py
@@ -920,6 +920,12 @@ class StreamingServerInterface(AgentChunkStreamingInterface):
         else:
             # Only warn for non-Claude models since Claude commonly has empty first chunks
             if not chunk.model.startswith("claude-"):
+                # Example case that would trigger here:
+                # id='chatcmpl-AKtUvREgRRvgTW6n8ZafiKuV0mxhQ'
+                # choices=[ChunkChoice(finish_reason=None, index=0, delta=MessageDelta(content=None, tool_calls=None, function_call=None), logprobs=None)]
+                # created=datetime.datetime(2024, 10, 21, 20, 40, 57, tzinfo=TzInfo(UTC))
+                # model='gpt-4o-mini-2024-07-18'
+                # object='chat.completion.chunk'
                 warnings.warn(f"Couldn't find delta in chunk: {chunk}")
             return None
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

I see these warning messages in the logs all the time:

> /app/letta/server/rest_api/interface.py:927: UserWarning: Couldn't find delta in chunk: id='msg_01RDprk8sYXHCoioWPLkZVjD' choices=[ChunkChoice(finish_reason=None, index=0, delta=MessageDelta(content=None, reasoning_content=None, tool_calls=None, role=None, function_call=None), logprobs=None)] created=datetime.datetime(2025, 3, 9, 3, 53, 34, 142573, tzinfo=datetime.timezone.utc) model='claude-3-5-sonnet-20241022' system_fingerprint=None object='chat.completion.chunk'

This is coming from https://github.com/letta-ai/letta/blob/main/letta/server/rest_api/interface.py#L927 -- however, this is normal and expected behavior from Claude, as in https://github.com/letta-ai/letta/blob/main/letta/server/rest_api/interface.py#L477

**How to test**

Send an empty chunk that is not claude and you should get a warning.

**Have you tested this PR?**

I have not tested this.
