### PR TITLE
Use default context window size if none found

### DIFF
--- a/letta/schemas/providers.py
+++ b/letta/schemas/providers.py
@@ -208,8 +208,7 @@ class OpenAIProvider(Provider):
         if model_name in LLM_MAX_TOKENS:
             return LLM_MAX_TOKENS[model_name]
         else:
-            return None
-
+            return LLM_MAX_TOKENS["DEFAULT"]
 
 class xAIProvider(OpenAIProvider):
     """https://docs.x.ai/docs/api-reference"""


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Using the openai_proxy, if there is no explicit context window size defined then the code will continue rather than use a default context window size.

There is a DEFAULT defined in LLM_MAX_TOKENS and it makes sense to use that so that the model name is returned correctly.

**How to test**

You should be able to create a model using an openai proxy that doesn't have a mapping in LLM_MAX_TOKENS and see it in ADE.

**Have you tested this PR?**

Nope!

