### PR TITLE
Fix optimistic json parser strict mode

### DIFF
--- a/letta/server/rest_api/optimistic_json_parser.py
+++ b/letta/server/rest_api/optimistic_json_parser.py
@@ -32,7 +32,7 @@ class OptimisticJSONParser:
         self.on_extra_token = self.default_on_extra_token
 
     def default_on_extra_token(self, text, data, reminding):
-        pass
+        print(f"Parsed JSON with extra tokens: {data}, remaining: {reminding}")
 
     def parse(self, input_str):
         """
@@ -130,8 +130,8 @@ class OptimisticJSONParser:
         if end == -1:
             # Incomplete string
             if not self.strict:
-                return input_str[1:], ""
-            return json.loads(f'"{input_str[1:]}"'), ""
+                return input_str[1:], ""  # Lenient mode returns partial string
+            raise decode_error  # Raise error for incomplete string in strict mode
 
         str_val = input_str[: end + 1]
         input_str = input_str[end + 1 :]
@@ -152,8 +152,8 @@ class OptimisticJSONParser:
         num_str = input_str[:idx]
         remainder = input_str[idx:]
 
-        # If it's only a sign or just '.', return as-is with empty remainder
-        if not num_str or num_str in {"-", "."}:
+        # If not strict, and it's only a sign or just '.', return as-is with empty remainder
+        if not self.strict and (not num_str or num_str in {"-", "."}):
             return num_str, ""
 
         try:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR mainly deals with the string and number parsing logic under strict mode in the optimistic JSON parser. The current implementation of `OptimisticJSONParser` failed 4 tests, as shown below:
```
FAILED tests/test_optimistic_json_parser.py::test_parse_boolean_true - AssertionError: No extra tokens expected.
FAILED tests/test_optimistic_json_parser.py::test_parse_incomplete_string_strict - Failed: Expected an error or partial parse with leftover tokens in strict mode.
FAILED tests/test_optimistic_json_parser.py::test_parse_incomplete_number_strict - Failed: DID NOT RAISE <class 'json.decoder.JSONDecodeError'>
FAILED tests/test_optimistic_json_parser.py::test_callback_invocation - AssertionError: Callback default_on_extra_token should print a message.
```
1. The `test_callback_invocation` failed because the `default_on_extra_token` printed no message, although the test expected one.
https://github.com/letta-ai/letta/blob/2bc30005bd0c432924a8ab0469329360ded6e137/letta/server/rest_api/optimistic_json_parser.py#L34-L35

2. The `test_parse_boolean_true` failed because the `strict_parser.last_parse_reminding` was set to `None` instead of an empty string.

3. The `test_parse_incomplete_string_strict` & `test_parse_incomplete_number_strict` failed cuz the `parse_string` and `parse_number` functions did not handle data parsing correctly in strict mode.

All the issues are addressed in this PR.

**How to test**
`poetry run pytest -s tests/test_optimistic_json_parser.py`

**Have you tested this PR?**
All 27 tests passed!

**Related issues or PRs**
fix #2495
