### PR TITLE
Fixed:  text_content is None which causes the openai api message format to be incorrect

### DIFF
--- a/letta/schemas/message.py
+++ b/letta/schemas/message.py
@@ -566,7 +566,7 @@ class Message(BaseMessage):
                 text_content = text[0].text
                 parse_content_parts = True
         else:
-            text_content = None
+            text_content = ""
 
         # TODO(caren) we should eventually support multiple content parts here?
         # ie, actually make dict['content'] type list
@@ -594,16 +594,17 @@ class Message(BaseMessage):
                 openai_message["name"] = self.name
 
         elif self.role == "assistant":
-            assert self.tool_calls is not None or text_content is not None
+            assert self.tool_calls or text_content
             openai_message = {
-                "content": None if put_inner_thoughts_in_kwargs else text_content,
+                "content": text_content,
                 "role": self.role,
             }
             # Optional fields, do not include if null
             if self.name is not None:
                 openai_message["name"] = self.name
-            if self.tool_calls is not None:
+            if self.tool_calls:
                 if put_inner_thoughts_in_kwargs:
+                    openai_message["content"] = text_content
                     # put the inner thoughts inside the tool call before casting to a dict
                     openai_message["tool_calls"] = [
                         add_inner_thoughts_to_tool_call(
@@ -657,7 +658,7 @@ class Message(BaseMessage):
         if self.content and len(self.content) == 1 and isinstance(self.content[0], TextContent):
             text_content = self.content[0].text
         else:
-            text_content = None
+            text_content = ""
 
         def add_xml_tag(string: str, xml_tag: Optional[str]):
             # NOTE: Anthropic docs recommends using <thinking> tag when using CoT + tool use
@@ -769,7 +770,7 @@ class Message(BaseMessage):
         if self.content and len(self.content) == 1 and isinstance(self.content[0], TextContent):
             text_content = self.content[0].text
         else:
-            text_content = None
+            text_content = ""
 
         if self.role != "tool" and self.name is not None:
             warnings.warn(f"Using Google AI with non-null 'name' field ({self.name}) not yet supported.")
@@ -901,7 +902,7 @@ class Message(BaseMessage):
         if self.content and len(self.content) == 1 and isinstance(self.content[0], TextContent):
             text_content = self.content[0].text
         else:
-            text_content = None
+            text_content = ""
         if self.role == "system":
             """
             The chat_history parameter should not be used for SYSTEM messages in most cases.


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
fixed a bug that text_content is None which causes the openai api message format to be incorrect

**How to test**
Hello, thank you for your open source. When I use openai 4o in letta, the model occasionally uses content instead of tool_calls (send message). In the next round of dialogue, put_inner_thoughts_in_kwargs sets content to None, while tool_calls is [], which causes the openai interface call to fail and any subsequent conversations to fail.

The first error:
![img_v3_02kq_7ce06be0-76af-49d7-b0f2-fc8e74e8197g](https://github.com/user-attachments/assets/b55f5c98-86b5-4e8c-aa34-806fa5c0ce9f)
Because content is None.

When content is not None, The second error:
![image](https://github.com/user-attachments/assets/d9588fd9-ee7c-46a8-a047-b85bc0409a55)
Because tool_calls=[]

**Have you tested this PR?**
Now I have fixed them:
```
        parse_content_parts = False
        if self.content and len(self.content) == 1 and isinstance(self.content[0], TextContent):
            text_content = self.content[0].text
        # Otherwise, check if we have TextContent and multiple other parts
        elif self.content and len(self.content) > 1:
            text = [content for content in self.content if isinstance(self.content[0], TextContent)]
            if len(text) > 1:
                assert len(text) == 1, f"multiple text content parts found in a single message: {self.content}"
                text_content = text[0].text
                parse_content_parts = True
        else:
            text_content = ""
```

```
        elif self.role == "assistant":
            assert self.tool_calls or text_content
            openai_message = {
                "content": text_content,
                "role": self.role,
            }
            # Optional fields, do not include if null
            if self.name is not None:
                openai_message["name"] = self.name
            if self.tool_calls:
                if put_inner_thoughts_in_kwargs:
                    openai_message["content"] = text_content
                    # put the inner thoughts inside the tool call before casting to a dict
                    openai_message["tool_calls"] = [
                        add_inner_thoughts_to_tool_call(
                            tool_call,
                            inner_thoughts=text_content,
                            inner_thoughts_key=INNER_THOUGHTS_KWARG,
                        ).model_dump()
                        for tool_call in self.tool_calls
                    ]
                else:
                    openai_message["tool_calls"] = [tool_call.model_dump() for tool_call in self.tool_calls]
                if max_tool_id_length:
                    for tool_call_dict in openai_message["tool_calls"]:
                        tool_call_dict["id"] = tool_call_dict["id"][:max_tool_id_length]
```
