### PR TITLE
fix: restore google_ai.py to fix broken utility

### DIFF
--- a/letta/llm_api/google_ai.py
+++ b/letta/llm_api/google_ai.py
@@ -1,0 +1,111 @@
+from typing import List, Optional, Tuple
+
+import requests
+
+from letta.utils import printd
+
+
+def get_gemini_endpoint_and_headers(
+    base_url: str, model: Optional[str], api_key: str, key_in_header: bool = True, generate_content: bool = False
+) -> Tuple[str, dict]:
+    """
+    Dynamically generate the model endpoint and headers.
+    """
+    url = f"{base_url}/v1beta/models"
+
+    # Add the model
+    if model is not None:
+        url += f"/{model}"
+
+    # Add extension for generating content if we're hitting the LM
+    if generate_content:
+        url += ":generateContent"
+
+    # Decide if api key should be in header or not
+    # Two ways to pass the key: https://ai.google.dev/tutorials/setup
+    if key_in_header:
+        headers = {"Content-Type": "application/json", "x-goog-api-key": api_key}
+    else:
+        url += f"?key={api_key}"
+        headers = {"Content-Type": "application/json"}
+
+    return url, headers
+
+
+def google_ai_get_model_details(base_url: str, api_key: str, model: str, key_in_header: bool = True) -> List[dict]:
+    """
+    Fetch details for a specific model from the Google AI API.
+    """
+    url, headers = get_gemini_endpoint_and_headers(base_url, model, api_key, key_in_header)
+
+    try:
+        response = requests.get(url, headers=headers)
+        printd(f"response = {response}")
+        response.raise_for_status()  # Raises HTTPError for 4XX/5XX status
+        response = response.json()  # convert to dict from string
+        printd(f"response.json = {response}")
+
+        # Grab the models out
+        return response
+
+    except requests.exceptions.HTTPError as http_err:
+        # Handle HTTP errors (e.g., response 4XX, 5XX)
+        printd(f"Got HTTPError, exception={http_err}")
+        # Print the HTTP status code
+        print(f"HTTP Error: {http_err.response.status_code}")
+        # Print the response content (error message from server)
+        print(f"Message: {http_err.response.text}")
+        raise http_err
+
+    except requests.exceptions.RequestException as req_err:
+        # Handle other requests-related errors (e.g., connection error)
+        printd(f"Got RequestException, exception={req_err}")
+        raise req_err
+
+    except Exception as e:
+        # Handle other potential errors
+        printd(f"Got unknown Exception, exception={e}")
+        raise e
+
+
+def google_ai_get_model_context_window(base_url: str, api_key: str, model: str, key_in_header: bool = True) -> int:
+    """
+    Fetch the context window size for a specific model from the Google AI API.
+    Assumes context window is the sum of input and output token limits.
+    """
+    model_details = google_ai_get_model_details(base_url, api_key, model, key_in_header)
+    input_limit = model_details.get("inputTokenLimit", 0)
+    output_limit = model_details.get("outputTokenLimit", 0)
+    return int(input_limit + output_limit)  # Sum of input and output limits
+
+
+def google_ai_get_model_list(base_url: str, api_key: str, key_in_header: bool = True) -> List[dict]:
+    url, headers = get_gemini_endpoint_and_headers(base_url, None, api_key, key_in_header)
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raises HTTPError for 4XX/5XX status
+        response = response.json()  # convert to dict from string
+
+        # Grab the models out
+        model_list = response["models"]
+        return model_list
+
+    except requests.exceptions.HTTPError as http_err:
+        # Handle HTTP errors (e.g., response 4XX, 5XX)
+        printd(f"Got HTTPError, exception={http_err}")
+        # Print the HTTP status code
+        print(f"HTTP Error: {http_err.response.status_code}")
+        # Print the response content (error message from server)
+        print(f"Message: {http_err.response.text}")
+        raise http_err
+
+    except requests.exceptions.RequestException as req_err:
+        # Handle other requests-related errors (e.g., connection error)
+        printd(f"Got RequestException, exception={req_err}")
+        raise req_err
+
+    except Exception as e:
+        # Handle other potential errors
+        printd(f"Got unknown Exception, exception={e}")
+        raise e


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR reintroduces `google_ai.py`, removed in f9a8aadf "chore: delete legacy google llm classes (#1402)", to fix "Module Not Found" Error mentioned in #2525.

Even though the commit https://github.com/letta-ai/letta/commit/ee61a74e5b989be7f17a97a36845e1de1fc7756b, ported some of the old functionality to a new file called `google_ai_client.py`, not all functions were included. For example, `google_ai_get_model_list` and `google_ai_get_model_context_window` were omitted. Since these two functions needed `get_gemini_endpoint_and_headers` as a helper, I included it in `google_ai.py` again even though it existed. So this PR might introduce some duplication.

https://github.com/letta-ai/letta/blob/6d383c363c8cd06fd8de5029136ae12f1e5f62f7/letta/llm_api/google_ai_client.py#L211-L238

**How to test**
```sh
export GEMINI_API_KEY="..."
letta run
```

**Have you tested this PR?**
Yes. After this PR, running `letta run` will show gemini models in the model list properly.

**Related issues or PRs**
resolves #2525
