### PR TITLE
Fix Gemini Function Calling Schema Incompatibilities

### DIFF
--- a/letta/llm_api/google_ai_client.py
+++ b/letta/llm_api/google_ai_client.py
@@ -263,6 +263,41 @@ class GoogleAIClient(LLMClientBase):
         except KeyError as e:
             raise e
 
+    def _clean_google_ai_schema_properties(self, schema_part: dict):
+        """Recursively clean schema parts to remove unsupported Google AI keywords."""
+        if not isinstance(schema_part, dict):
+            return
+
+        # Per https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#notes_and_limitations
+        # * Only a subset of the OpenAPI schema is supported.
+        # * Supported parameter types in Python are limited.
+        unsupported_keys = ["default", "exclusiveMaximum", "exclusiveMinimum"]
+        keys_to_remove_at_this_level = [key for key in unsupported_keys if key in schema_part]
+        for key_to_remove in keys_to_remove_at_this_level:
+            logger.warning(f"Removing unsupported keyword 	'{key_to_remove}' from schema part.")
+            del schema_part[key_to_remove]
+
+        if schema_part.get("type") == "string" and "format" in schema_part:
+            allowed_formats = ["enum", "date-time"]
+            if schema_part["format"] not in allowed_formats:
+                logger.warning(f"Removing unsupported format 	'{schema_part['format']}' for string type. Allowed: {allowed_formats}")
+                del schema_part["format"]
+
+        # Check properties within the current level
+        if "properties" in schema_part and isinstance(schema_part["properties"], dict):
+            for prop_name, prop_schema in schema_part["properties"].items():
+                self._clean_google_ai_schema_properties(prop_schema)
+
+        # Check items within arrays
+        if "items" in schema_part and isinstance(schema_part["items"], dict):
+            self._clean_google_ai_schema_properties(schema_part["items"])
+
+        # Check within anyOf, allOf, oneOf lists
+        for key in ["anyOf", "allOf", "oneOf"]:
+            if key in schema_part and isinstance(schema_part[key], list):
+                for item_schema in schema_part[key]:
+                    self._clean_google_ai_schema_properties(item_schema)
+
     def convert_tools_to_google_ai_format(self, tools: List[Tool]) -> List[dict]:
         """
         OpenAI style:
@@ -321,6 +356,10 @@ class GoogleAIClient(LLMClientBase):
         # Add inner thoughts if needed
         for func in function_list:
             # Note: Google AI API used to have weird casing requirements, but not any more
+
+            # Google AI API only supports a subset of OpenAPI 3.0, so unsupported params must be cleaned
+            if "parameters" in func and isinstance(func["parameters"], dict):
+                self._clean_google_ai_schema_properties(func["parameters"])
 
             # Add inner thoughts
             if self.llm_config.put_inner_thoughts_in_kwargs:

--- a/letta/orm/message.py
+++ b/letta/orm/message.py
@@ -67,6 +67,7 @@ class Message(SqlalchemyBase, OrganizationMixin, AgentMixin):
             model.content = [PydanticTextContent(text=self.text)]
         return model
 
+
 # listener
 
 


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

This pull request fixes a bug where agents using Gemini models (`gemini-2.5-pro-exp-03-25`, etc.) encounter 400 Bad Request errors when attempting to use tools whose schemas contain certain standard OpenAPI keywords. The Gemini API's function calling feature only supports a limited subset of the OpenAPI 3.0 specification, and keywords like `default`, `exclusiveMaximum`, `exclusiveMinimum`, and specific `format` values (e.g., `"uri"`) are not recognized, leading to `INVALID_ARGUMENT` errors.

This PR modifies the `GoogleAIClient` to proactively clean these unsupported keywords from tool schemas before they are sent to the Gemini API, ensuring compatibility and preventing runtime errors.

**How to test**

First, download https://github.com/wsargent/groundedllm, set up an `.env` file with keys, and run `docker compose up`.
 
1.  Configure the search agent to use a Gemini model capable of function calling (e.g., `gemini-2.5-pro-exp-03-25`).
2.  Attach an MCP tool that provides schemas containing known unsupported keywords. The `aws-documentation-mcp-server` tools, specifically `read_documentation`, are a good test case as its schema includes `default`, `exclusiveMaximum`, `exclusiveMinimum`, and `format: "uri"`.
3.  **(Without the fix):** Run the agent and attempt to invoke the tool (e.g., by asking it to read an AWS documentation page). Observe the `letta` logs for a 400 Client Error from `generativelanguage.googleapis.com` with an `INVALID_ARGUMENT` status, mentioning one of the unsupported keywords (`default`, `exclusiveMaximum`, `exclusiveMinimum`, or `format`).
4.  **Apply the fix from this PR.**
5.  **(With the fix):** Run the agent again and attempt the same tool invocation.
    *   **Expected Outcome 1:** Check the `letta` logs for `WARNING` messages from `Letta.letta.llm_api.google_ai_client` indicating the removal of the unsupported keywords (e.g., "Parameter 'max_length' contains unsupported keyword default... Removing it.").
    *   **Expected Outcome 2:** Verify that the previous 400 `INVALID_ARGUMENT` error related to schema keywords no longer occurs. The function call should now proceed to the Gemini API without this specific schema parsing error.

**Have you tested this PR?**

Yes, this PR was developed iteratively based on debugging logs. The process involved:
1.  Identifying the initial `Unknown name "default"` error.
2.  Implementing a fix to remove `default` and verifying its removal via logs.
3.  Identifying subsequent errors for `exclusiveMaximum` and `exclusiveMinimum`.
4.  Updating the fix to remove these keywords and verifying their removal via logs.
5.  Identifying the final error related to `format: "uri"`.
6.  Implementing the recursive cleaning logic to handle `format` and other keywords within nested structures (like `anyOf`).

Logs confirmed that each unsupported keyword identified during debugging was successfully removed by the code changes in this PR, resolving the sequence of 400 errors related to schema incompatibility.

**Related issues or PRs**

None known.

**Is your PR over 500 lines of code?**

No, the changes are localized to the `GoogleAIClient` and involve adding a helper function and modifying the tool conversion logic, well under the 500-line threshold.

**Additional context**

The root cause is the discrepancy between the standard OpenAPI 3.0 schemas often generated by tools/servers and the specific, more limited subset supported by the Google Gemini API for function calling. This client-side cleaning approach provides a workaround without requiring changes to the upstream tool providers.