### PR TITLE
fix: add developer message to cast_message_to_subtype

### DIFF
--- a/letta/schemas/openai/chat_completion_request.py
+++ b/letta/schemas/openai/chat_completion_request.py
@@ -63,7 +63,7 @@ def cast_message_to_subtype(m_dict: dict) -> ChatMessage:
     elif role == "tool":
         return ToolMessage(**m_dict)
     else:
-        raise ValueError("Unknown message role")
+        raise ValueError(f"Unknown message role: {role}")
 
 
 class ResponseFormat(BaseModel):

--- a/letta/schemas/openai/chat_completion_request.py
+++ b/letta/schemas/openai/chat_completion_request.py
@@ -9,6 +9,12 @@ class SystemMessage(BaseModel):
     name: Optional[str] = None
 
 
+class DeveloperMessage(BaseModel):
+    content: str
+    role: str = "developer"
+    name: Optional[str] = None
+
+
 class UserMessage(BaseModel):
     content: Union[str, List[str]]
     role: str = "user"
@@ -48,6 +54,8 @@ def cast_message_to_subtype(m_dict: dict) -> ChatMessage:
     role = m_dict.get("role")
     if role == "system":
         return SystemMessage(**m_dict)
+    elif role == 'developer':
+        return DeveloperMessage(**m_dict)
     elif role == "user":
         return UserMessage(**m_dict)
     elif role == "assistant":


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR fixes a bug when using OpenAI reasoner models. These models map "system" messages to be "developer" instead, but the `cast_message_to_subtype` function did not support this role, raising ValueErrors when the messages were created.

Example stack trace:
![image](https://github.com/user-attachments/assets/1e51ece1-3ec8-43e6-9380-07983c6836c6)

**Related issues or PRs**
Discussed on Discord.