### PR TITLE
Fix uninitialized `tool_names` variable in GoogleAIClient

### DIFF
--- a/letta/llm_api/google_ai_client.py
+++ b/letta/llm_api/google_ai_client.py
@@ -50,6 +50,8 @@ class GoogleAIClient(LLMClientBase):
         """
         Constructs a request object in the expected data format for this client.
         """
+        tool_names = []
+
         if tools:
             tools = [{"type": "function", "function": f} for f in tools]
             tool_objs = [Tool(**t) for t in tools]


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
`tool_names` is an unbound variable here. This PR fixes it by initializing it first. Resolves #2564.

**Have you tested this PR?**
Yes, I manually tested this PR in the ADE, by chatting with Gemini models multiple rounds to trigger the `summarize` method.
