### PR TITLE
fix: only trim in-context messages to cutoff

### DIFF
--- a/letta/agent.py
+++ b/letta/agent.py
@@ -1103,7 +1103,7 @@ class Agent(BaseAgent):
         logger.info(f"Packaged into message: {summary_message}")
 
         prior_len = len(in_context_messages_openai)
-        self.agent_state = self.agent_manager.trim_all_in_context_messages_except_system(agent_id=self.agent_state.id, actor=self.user)
+        self.agent_state = self.agent_manager.trim_older_in_context_messages(num=cutoff, agent_id=self.agent_state.id, actor=self.user)
         packed_summary_message = {"role": "user", "content": summary_message}
         # Prepend the summary
         self.agent_state = self.agent_manager.prepend_to_in_context_messages(


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

There is a bug in `summarize_messages_inplace()` that causes the agent to throw out all of its messages every time it summarizes, instead of only those up to `[:cutoff]`. This was caused by a call to `trim_all_in_context_messages_except_system()` which blanks the message stream instead of `trim_older_in_context_messages(num=cutoff)` which would only remove the earliest messages in the stream.

This PR swaps the `trim_*()` function in summarization.

**Additional context**

The symptom of this is that the context window messages are totally emptied every time summarization runs.

![image](https://github.com/user-attachments/assets/d6132349-128b-44bb-bab5-831d8ba062f3)
