### PR TITLE
fix: fix role access in GoogleAIClient to use default value

### DIFF
--- a/letta/llm_api/google_ai_client.py
+++ b/letta/llm_api/google_ai_client.py
@@ -122,7 +122,7 @@ class GoogleAIClient(LLMClientBase):
             for candidate in response_data["candidates"]:
                 content = candidate["content"]
 
-                role = content["role"]
+                role = content.get("role", "model")
                 assert role == "model", f"Unknown role in response: {role}"
 
                 parts = content["parts"]


### PR DESCRIPTION

**Please describe the purpose of this pull request.**
This PR fixes a bug in the Google AI client where the code was failing with a KeyError: 'role' exception. The issue occurs when the Google AI API response doesn't include the 'role' key in the content dictionary, which appears to be a recent change in the API's response format. The fix makes the code more robust by using the `.get()` method with a default value instead of direct dictionary access, allowing it to handle cases where the 'role' key is missing.

**How to test**
To test this PR:
1. Deploy the changes to a test environment
2. Send a request to the Google AI API using the `google_ai_client.py` functionality
3. Verify that the request completes successfully without the KeyError: 'role' exception
4. If possible, test with different models, especially with Gemini 2.5 models which were particularly affected

Expected outcome: The client should be able to process the API responses correctly even when the 'role' key is missing.

**Have you tested this PR?**
Yes, I have tested this PR. The fix successfully handles responses from the Google AI API that don't include the 'role' key in the content dictionary. After implementing the change, the previously failing requests now complete successfully. The fix is minimal and only affects the specific area of the code that was causing the exception.

**Related issues or PRs**
This PR addresses an issue where users were experiencing KeyError: 'role' exceptions when using the Google AI client, particularly with Gemini 2.5 models. The issue appears to be due to a recent change in the API's response format.

**Is your PR over 500 lines of code?**
No, this PR is a minimal fix modifying only one line of code to use dict.get() with a default value instead of direct dictionary access, making the code more robust against missing keys in the API response.

**Additional context**
This issue seems to be related to recent changes in the Google AI API response format. Many users in the Google AI Developers Forum have reported similar issues with missing keys in responses, particularly with Gemini 2.5 models. This fix makes our client more resilient to such API changes.
