### PR TITLE
Fix SleepTimeMultiAgent MCP Tool Usage

### DIFF
--- a/letta/groups/sleeptime_multi_agent.py
+++ b/letta/groups/sleeptime_multi_agent.py
@@ -42,6 +42,7 @@ class SleeptimeMultiAgent(Agent):
         self.group_manager = GroupManager()
         self.message_manager = MessageManager()
         self.job_manager = JobManager()
+        self.mcp_clients = mcp_clients
 
     def _run_async_in_new_thread(self, coro):
         """Run an async coroutine in a new thread with its own event loop"""


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR fixes a bug in the SleepTimeMultiAgent class where the mcp_clients argument was not utilized. This prevents SleepTimeMultiAgent Agents from calling tools provided by MCP servers.


**How to test**
1. Create a SleepTime Agent using the method displayed [in the examples](https://github.com/letta-ai/letta/blob/main/examples/sleeptime/sleeptime_example.py)
2. Attach MCP tools to the new agent
3. Instruct the agent to run a tool

Prior to this change, The agent would show "Error executing function my_mcp_tool: ValueError: No MCP client available to use" in the ADE, as shown below.
![image](https://github.com/user-attachments/assets/857e5d3a-2451-470c-9758-0557adca10e1)

With this change in place, the tool call is successful.

**Have you tested this PR?**
![image](https://github.com/user-attachments/assets/d176a4cd-f4c2-4ba0-90c8-aa390906f3ee)

**Related issues or PRs**
Couldn't find any. 

**Is your PR over 500 lines of code?**
No. +1/-0

**Additional context**
