### PR TITLE
Pass MCP env to STDIO MCP client

### DIFF
--- a/letta/functions/mcp_client/stdio_client.py
+++ b/letta/functions/mcp_client/stdio_client.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 class StdioMCPClient(BaseMCPClient):
     def _initialize_connection(self, server_config: StdioServerConfig, timeout: float) -> bool:
         try:
-            server_params = StdioServerParameters(command=server_config.command, args=server_config.args)
+            server_params = StdioServerParameters(command=server_config.command, args=server_config.args, env=server_config.env)
             stdio_cm = forked_stdio_client(server_params)
             stdio_transport = self.loop.run_until_complete(asyncio.wait_for(stdio_cm.__aenter__(), timeout=timeout))
             self.stdio, self.write = stdio_transport

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -1615,6 +1615,7 @@ class SyncServer(Server):
                                     server_name=server_name,
                                     command=server_params_raw["command"],
                                     args=server_params_raw.get("args", []),
+                                    env=server_params_raw.get("env", {})
                                 )
                                 mcp_server_list[server_name] = server_params
                             except Exception as e:


### PR DESCRIPTION
# Pass MCP env to STDIO MCP client

**Please describe the purpose of this pull request.**
This PR adds wires up the passing of environment variables to STDIO MCP server processes. 

**How to test**
To test this PR:

1. Configure an MCP server with environment variables in your config file:
```json
{
  "mcpServers": {
    "myServer": {
      "command": "/path/to/server",
      "args": [],
      "env": {
        "SOME_ENV_VAR": "SOME_ENV_VAR"
      }
    }
  }
}
```

2. Start the server and verify that the environment variables are correctly passed to the child process:
3. You can verify the environment variables are passed correctly by having the server process print its environment variables or by checking behavior that depends on those variables.

**Have you tested this PR?**
Yes, I have tested this PR with a server that reads environment variables for configuration. The server successfully received and processed the environment variables specified in the config.


**Related issues or PRs**
Searched and found None.

**Is your PR over 500 lines of code?**
No, +2/-0

**Additional context**
This change is backward compatible as the environment variable dictionary defaults to an empty dict when not specified in the configuration. Existing server configurations will continue to work without modification.