### PR TITLE
fix: enable anthropic bedrock models

### DIFF
--- a/letta/llm_api/aws_bedrock.py
+++ b/letta/llm_api/aws_bedrock.py
@@ -63,12 +63,24 @@ def bedrock_get_model_list(region_name: str) -> List[dict]:
 
     logger.debug(f"Getting model list for {region_name}")
     try:
-        bedrock = boto3.client("bedrock", region_name=region_name)
+        bedrock = boto3.client(
+            "bedrock",
+            aws_access_key_id=model_settings.aws_access_key,
+            aws_secret_access_key=model_settings.aws_secret_access_key,
+            region_name=region_name or model_settings.aws_region,
+        )
         response = bedrock.list_inference_profiles()
         return response["inferenceProfileSummaries"]
     except Exception as e:
         logger.exception(f"Error getting model list: {str(e)}", e)
         raise e
+
+
+async def bedrock_get_model_list_async(region_name: str) -> List[dict]:
+    """Asynchronous version to get model list from Bedrock."""
+    import asyncio
+
+    return await asyncio.to_thread(bedrock_get_model_list, region_name)
 
 
 def bedrock_get_model_details(region_name: str, model_id: str) -> Dict[str, Any]:
@@ -88,6 +100,13 @@ def bedrock_get_model_details(region_name: str, model_id: str) -> Dict[str, Any]
         raise e
 
 
+async def bedrock_get_model_details_async(region_name: str, model_id: str) -> Dict[str, Any]:
+    """Asynchronous version to get model details for a specific model from Bedrock."""
+    import asyncio
+
+    return await asyncio.to_thread(bedrock_get_model_details, region_name, model_id)
+
+
 def bedrock_get_model_context_window(model_id: str) -> int:
     """
     Get context window size for a specific model.
@@ -102,6 +121,13 @@ def bedrock_get_model_context_window(model_id: str) -> int:
         "anthropic.claude-3-sonnet-20240229-v1:0": 200000,
     }
     return context_windows.get(model_id, 200000)  # default to 100k if unknown
+
+
+async def bedrock_get_model_context_window_async(model_id: str) -> int:
+    import asyncio
+
+    """Asynchronous version to get context window size for a specific model."""
+    return await asyncio.to_thread(bedrock_get_model_context_window, model_id)
 
 
 """

--- a/letta/schemas/openai/chat_completion_request.py
+++ b/letta/schemas/openai/chat_completion_request.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SystemMessage(BaseModel):
@@ -116,6 +116,8 @@ FunctionCallChoice = Union[Literal["none", "auto"], FunctionCall]
 
 class ChatCompletionRequest(BaseModel):
     """https://platform.openai.com/docs/api-reference/chat/create"""
+
+    model_config = ConfigDict(extra="allow")
 
     model: str
     messages: List[Union[ChatMessage, Dict]]

--- a/letta/schemas/providers.py
+++ b/letta/schemas/providers.py
@@ -1539,6 +1539,28 @@ class AnthropicBedrockProvider(Provider):
             )
         return configs
 
+    async def list_llm_models_async(self):
+        from letta.llm_api.aws_bedrock import bedrock_get_model_list_async
+
+        models = await bedrock_get_model_list_async(self.aws_region)
+
+        configs = []
+        for model_summary in models:
+            model_arn = model_summary["inferenceProfileArn"]
+            context_window = await self.get_model_context_window_async(model_arn)
+            configs.append(
+                LLMConfig(
+                    model=model_arn,
+                    model_endpoint_type=self.provider_type.value,
+                    model_endpoint=None,
+                    context_window=context_window,
+                    handle=self.get_handle(model_arn),
+                    provider_name=self.name,
+                    provider_category=self.provider_category,
+                )
+            )
+        return configs
+
     def list_embedding_models(self):
         return []
 
@@ -1547,6 +1569,12 @@ class AnthropicBedrockProvider(Provider):
         from letta.llm_api.aws_bedrock import bedrock_get_model_context_window
 
         return bedrock_get_model_context_window(model_name)
+
+    async def get_model_context_window_async(self, model_name: str) -> Optional[int]:
+        # Context windows for Claude models
+        from letta.llm_api.aws_bedrock import bedrock_get_model_context_window_async
+
+        return await bedrock_get_model_context_window_async(model_name)
 
     def get_handle(self, model_name: str) -> str:
         print(model_name)


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This bug fix enables Bedrock model usage by implementing async functions for the `AnthropicBedrockProvider`.

**How to test**
Set AWS environment variables and Use the List LLM Models API to list bedrock models.
Create an agent with a bedrock model and message it successfully.

**Have you tested this PR?**
```python
from letta_client import Letta
from letta_client.types import CreateBlock, MessageCreate

# For self-hosted, use the base_url parameter
client = Letta(base_url="http://localhost:8283")

# Create an agent with memory blocks and the custom tool
agent = client.agents.create(
    name="test-agent",
    memory_blocks=[
        CreateBlock(
            label="persona",
            value="You are a helpful assistant.",
        ),
        CreateBlock(
            label="human",
            value="The user is a customer asking for information about their order.",
        ),
    ],
    model="bedrock/claude-3-5-sonnet-20240620-v1:0",
    embedding="openai/text-embedding-3-small"
)

# Send a message to the agent
message_text = "Hi, how are you?"
response = client.agents.messages.create(
    agent_id=agent.id,
    messages=[MessageCreate(role="user", content=message_text)]
)

def print_message(message):
    if message.message_type == "reasoning_message":
        print("🧠 Reasoning: " + message.reasoning)
    elif message.message_type == "assistant_message":
        print("🤖 Agent: " + message.content)
    elif message.message_type == "tool_call_message":
        print("🔧 Tool Call: " + message.tool_call.name + "\n" + message.tool_call.arguments)
    elif message.message_type == "tool_return_message":
        print("🔧 Tool Return: " + message.tool_return)
    elif message.message_type == "user_message":
        print("👤 User Message: " + message.content)
    elif message.message_type == "usage_statistics":
        # for streaming specifically, we send the final chunk that contains the usage statistics
        print(f"Usage: [{message}]")
    else:
        print(message)
    print("-----------------------------------------------------")


# Print the assistant's response
for msg in response.messages:
    print_message(msg)

```

<img width="1483" alt="Screenshot 2025-06-20 at 9 24 06 PM" src="https://github.com/user-attachments/assets/c4d5714b-fadf-44e9-9c9c-ce288a046e29" />

<img width="1477" alt="Screenshot 2025-06-20 at 9 25 26 PM" src="https://github.com/user-attachments/assets/147b9f30-2f7a-4fe7-ba9f-9d67569ed75f" />

**Additional context**
The `bedrock_get_model_list` function was updated to consistently use credentials from `model_settings` instead of attempting to retrieve them from environment variables. This change resolves a credential mismatch issue where boto3 expects the environment variable `AWS_ACCESS_KEY_ID` but Letta uses `AWS_ACCESS_KEY`.
