### PR TITLE
fix: all model types returned from ollama provider

### DIFF
--- a/letta/constants.py
+++ b/letta/constants.py
@@ -10,6 +10,7 @@ DEFAULT_TIMEZONE = "UTC"
 
 ADMIN_PREFIX = "/v1/admin"
 API_PREFIX = "/v1"
+OLLAMA_API_PREFIX = "/v1"
 OPENAI_API_PREFIX = "/openai"
 
 COMPOSIO_ENTITY_ENV_VAR_KEY = "COMPOSIO_ENTITY"
@@ -50,8 +51,9 @@ TOOL_CALL_ID_MAX_LEN = 29
 # Max steps for agent loop
 DEFAULT_MAX_STEPS = 50
 
-# minimum context window size
+# context window size
 MIN_CONTEXT_WINDOW = 4096
+DEFAULT_CONTEXT_WINDOW = 32000
 
 # number of concurrent embedding requests to sent
 EMBEDDING_BATCH_SIZE = 200
@@ -63,6 +65,7 @@ DEFAULT_MIN_MESSAGE_BUFFER_LENGTH = 15
 # embeddings
 MAX_EMBEDDING_DIM = 4096  # maximum supported embeding size - do NOT change or else DBs will need to be reset
 DEFAULT_EMBEDDING_CHUNK_SIZE = 300
+DEFAULT_EMBEDDING_DIM = 1024
 
 # tokenizers
 EMBEDDING_TO_TOKENIZER_MAP = {


### PR DESCRIPTION
Makes sure only completion models are returned from `list_llm_models_async` and only embeddings from `list_embedding_models_async`, instead of both from each. Also some minor refactoring, moving constants to [constants.py](../blob/main/letta/constants.py).

**How to test**
Run `/v1/models` and `/v1/models/embedding` and see that the models returned are completion models and embeddings respectively, currently in main both are returned together for each endpoint.

**Have you tested this PR?**
Yes, as above.

**Related issues or PRs**
Fixes the second issue discussed in https://github.com/letta-ai/letta/issues/2739.

One more optimization here would be to cache the calls to `/api/show` since they all have to be fetched for both functions, but this probably adds more complexity than it's worth at this stage.