### PR TITLE
fix: incorrect URL for Ollama embeddings endpoint

### DIFF
--- a/letta/embeddings.py
+++ b/letta/embeddings.py
@@ -159,7 +159,7 @@ class OllamaEmbeddings:
 
         with httpx.Client() as client:
             response = client.post(
-                f"{self.base_url}/api/embeddings",
+                f"{self.base_url}/embeddings",
                 headers=headers,
                 json=json_data,
             )

--- a/letta/embeddings.py
+++ b/letta/embeddings.py
@@ -139,10 +139,11 @@ class AzureOpenAIEmbedding:
 
 class OllamaEmbeddings:
 
+    # Uses OpenAI API standard
     # Format:
-    # curl http://localhost:11434/api/embeddings -d '{
+    # curl http://localhost:11434/v1/embeddings -d '{
     #   "model": "mxbai-embed-large",
-    #   "prompt": "Llamas are members of the camelid family"
+    #   "input": "Llamas are members of the camelid family"
     # }'
 
     def __init__(self, model: str, base_url: str, ollama_additional_kwargs: dict):
@@ -154,7 +155,7 @@ class OllamaEmbeddings:
         import httpx
 
         headers = {"Content-Type": "application/json"}
-        json_data = {"model": self.model, "prompt": text}
+        json_data = {"model": self.model, "input": text}
         json_data.update(self.ollama_additional_kwargs)
 
         with httpx.Client() as client:
@@ -165,7 +166,7 @@ class OllamaEmbeddings:
             )
 
         response_json = response.json()
-        return response_json["embedding"]
+        return response_json["data"][0]["embedding"]
 
 
 class GoogleEmbeddings:


### PR DESCRIPTION
Fixes adding archival memories failing because of getting a 404 from Ollama's embeddings endpoint. Since the prefixing of the base url with `/v1` (OpenAI API standard) happens elsewhere and is even saved in the database, it's easier to fix this by changing the URL to the OpenAI endpoint rather than the native Ollama one for now.

Apart from the API URL the request and response data was adjusted to match the current endpoint, instead of the deprecated one.

**How to test**
Add archival memory to agent when using Ollama backend.

**Have you tested this PR?**
Yes, memories can now be added.

**Related issues or PRs**
https://github.com/letta-ai/letta/issues/2747