### PR TITLE
mv dictconfig out of getlogger

### DIFF
--- a/letta/log.py
+++ b/letta/log.py
@@ -61,13 +61,15 @@ DEVELOPMENT_LOGGING = {
     },
 }
 
+# Configure logging once at module initialization to avoid performance overhead
+dictConfig(DEVELOPMENT_LOGGING)
+
 
 def get_logger(name: Optional[str] = None) -> "logging.Logger":
     """returns the project logger, scoped to a child name if provided
     Args:
         name: will define a child logger
     """
-    dictConfig(DEVELOPMENT_LOGGING)
     parent_logger = logging.getLogger("Letta")
     if name:
         return parent_logger.getChild(name)


### PR DESCRIPTION
  Problem

  CPU profiling revealed that _clear_cache() in Python's logging module was consuming a lot of CPU time

  Root Cause Analysis

  - Every get_logger() call executed dictConfig(DEVELOPMENT_LOGGING)
  - With 30+ modules calling get_logger() multiple times per request
  - This resulted in hundreds of complete logging system reconfigurations per request
  - Each reconfiguration triggered setLevel() → _clear_cache() overhead

  Performance impact: Significant CPU time was spent reconfiguring the same logging setup repeatedly instead of
  processing actual requests.

  Solution

  Move dictConfig() from per-function call to module initialization:

  Before:
  def get_logger(name=None):
      dictConfig(DEVELOPMENT_LOGGING)  # ← Called hundreds of times per request
      return logging.getLogger("Letta")

  After:
  # Configure logging once at module initialization
  dictConfig(DEVELOPMENT_LOGGING)

  def get_logger(name=None):
      return logging.getLogger("Letta")  # ← Lightweight logger retrieval

  Impact

  - Performance: Reduction in CPU overhead
  - Scalability: Eliminates O(n) logging configuration per request
  - Functionality: Zero changes to logging behavior
  - Pattern: Follows standard Python logging best practices

  Safety

  ✅ No functional changes - identical logging output and behavior
  ✅ Thread-safe - Python's getLogger() is inherently thread-safe
  ✅ Standard pattern - matches recommended Python logging configuration
  ✅ Error handling - configuration errors now fail fast at import time

  This is a high-impact performance optimization that eliminates the primary CPU bottleneck identified in profiling.