### PR TITLE
fix: revert regression in OllamaProvider

### DIFF
--- a/letta/schemas/providers/ollama.py
+++ b/letta/schemas/providers/ollama.py
@@ -82,8 +82,18 @@ class OllamaProvider(OpenAIProvider):
                 response_json = await response.json()
 
         configs = []
-        for model in response_json["models"]:
-            embedding_dim = await self._get_model_embedding_dim(model["name"])
+        for model in response_json.get("models", []):
+            model_name = model["name"]
+            model_details = await self._get_model_details_async(model_name)
+            if not model_details or "embedding" not in model_details.get("capabilities", []):
+                continue
+
+            embedding_dim = None
+            model_info = model_details.get("model_info", {})
+            if architecture := model_info.get("general.architecture"):
+                if embedding_length := model_info.get(f"{architecture}.embedding_length"):
+                    embedding_dim = int(embedding_length)
+
             if not embedding_dim:
                 logger.warning(f"Ollama model {model_name} has no embedding dimension, using default {DEFAULT_EMBEDDING_DIM}")
                 embedding_dim = DEFAULT_EMBEDDING_DIM


### PR DESCRIPTION
Reverted changes in `OllamaProvider.list_embedding_models_async` that caused regression in release [0.11.4](https://github.com/letta-ai/letta/releases/tag/0.11.4).

**How to test**
Endpoint `/v1/models/embedding` doesn't return any embeddings from Ollama backend, and throws an error in the server log.

**Have you tested this PR?**
Yes, as above.

**Related issues or PRs**
Issue https://github.com/letta-ai/letta/issues/2774
