### PR TITLE
test: relax string matching in send message tests

### DIFF
--- a/tests/integration_test_send_message.py
+++ b/tests/integration_test_send_message.py
@@ -231,7 +231,7 @@ def assert_greeting_with_assistant_message_response(
     assert isinstance(messages[index], AssistantMessage)
     if not token_streaming:
         # Check for either short or long response
-        assert USER_MESSAGE_RESPONSE in messages[index].content or USER_MESSAGE_LONG_RESPONSE in messages[index].content
+        assert "teamwork" in messages[index].content.lower() or USER_MESSAGE_LONG_RESPONSE in messages[index].content
     assert messages[index].otid and messages[index].otid[-1] == "1"
     index += 1
 
@@ -268,7 +268,7 @@ def assert_greeting_no_reasoning_response(
     # Agent Step 1 - should be AssistantMessage directly, no reasoning
     assert isinstance(messages[index], AssistantMessage)
     if not token_streaming:
-        assert USER_MESSAGE_RESPONSE in messages[index].content
+        assert "teamwork" in messages[index].content.lower()
     assert messages[index].otid and messages[index].otid[-1] == "0"
     index += 1
 
@@ -314,7 +314,7 @@ def assert_greeting_without_assistant_message_response(
     assert isinstance(messages[index], ToolCallMessage)
     assert messages[index].tool_call.name == "send_message"
     if not token_streaming:
-        assert USER_MESSAGE_RESPONSE in messages[index].tool_call.arguments
+        assert "teamwork" in messages[index].tool_call.arguments.lower()
     assert messages[index].otid and messages[index].otid[-1] == "1"
     index += 1
 


### PR DESCRIPTION
The current tests use an exact string match, but some of the chattier models don't work well with this:
```
FAILED tests/integration_test_send_message.py::test_greeting_with_assistant_message[gemini-2.5-flash] - assert ('Teamwork makes the dream work' in "Hello there! It's so lovely to meet you. You know, I was just thinking, teamwork really does make the dream work!" or "Teamwork makes the dream work. When people collaborate and combine their unique skills, perspectives, and experiences, they can achieve far more than any individual working alone. This synergy creates an environment where innovation flourishes, problems are solved more creatively, and goals are reached more efficiently. In a team setting, diverse viewpoints lead to better decision-making as different team members bring their unique backgrounds and expertise to the table. Communication becomes the backbone of success, allowing ideas to flow freely and ensuring everyone is aligned toward common objectives. Trust builds gradually as team members learn to rely on each other's strengths while supporting one another through challenges. The collective intelligence of a group often surpasses that of even the brightest individual, as collaboration sparks creativity and innovation. Successful teams celebrate victories together and learn from failures as a unit, creating a culture of continuous improvement. Together, we can overcome challenges that would be insurmountable alone, achieving extraordinary results through the power of collaboration." in "Hello there! It's so lovely to meet you. You know, I was just thinking, teamwork really does make the dream work!")
```