### PR TITLE
fix: logger error in streaming interface

### DIFF
--- a/letta/interfaces/anthropic_streaming_interface.py
+++ b/letta/interfaces/anthropic_streaming_interface.py
@@ -226,7 +226,7 @@ class AnthropicStreamingInterface:
         except Exception as e:
             import traceback
 
-            logger.error("Error processing stream: %s", e, traceback.format_exc())
+            logger.error("Error processing stream: %s\n%s", e, traceback.format_exc())
             ttft_span.add_event(
                 name="stop_reason",
                 attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},

--- a/letta/interfaces/openai_streaming_interface.py
+++ b/letta/interfaces/openai_streaming_interface.py
@@ -166,7 +166,7 @@ class OpenAIStreamingInterface:
         except Exception as e:
             import traceback
 
-            logger.error("Error processing stream: %s", e, traceback.format_exc())
+            logger.error("Error processing stream: %s\n%s", e, traceback.format_exc())
             ttft_span.add_event(
                 name="stop_reason",
                 attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},


### PR DESCRIPTION
Stacktrace:
```  
"/home/ci-runner/actions-runner/_work/letta/letta/letta/interfaces/anthropic_streaming_interface.py", line
   229, in process
      logger.error("Error processing stream: %s", e, traceback.format_exc())
    File "/usr/lib/python3.12/logging/__init__.py", line 1568, in error
      self._log(ERROR, msg, args, **kwargs)
    File "/usr/lib/python3.12/logging/__init__.py", line 1684, in _log
      self.handle(record)
    File "/usr/lib/python3.12/logging/__init__.py", line 1700, in handle
      self.callHandlers(record)
    File "/usr/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
      hdlr.handle(record)
    File "/usr/lib/python3.12/logging/__init__.py", line 1028, in handle
      self.emit(record)
    File 
  "/home/ci-runner/actions-runner/_work/letta/letta/.venv/lib/python3.12/site-packages/_pytest/logging.py", 
  line 384, in emit
      super().emit(record)
    File "/usr/lib/python3.12/logging/__init__.py", line 1168, in emit
      self.handleError(record)
    File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
      msg = self.format(record)
            ^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
      return fmt.format(record)
             ^^^^^^^^^^^^^^^^^^
    File 
  "/home/ci-runner/actions-runner/_work/letta/letta/.venv/lib/python3.12/site-packages/_pytest/logging.py", 
  line 137, in format
      return super().format(record)
             ^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
      record.message = record.getMessage()
                       ^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
      msg = msg % self.args
            ~~~~^~~~~~~~~~~
  TypeError: not all arguments converted during string formatting
  ```