### PR TITLE
feat: Scrub env vars

### DIFF
--- a/letta/services/agent_serialization_manager.py
+++ b/letta/services/agent_serialization_manager.py
@@ -208,6 +208,10 @@ class AgentSerializationManager:
         )
         agent_schema.id = agent_file_id
 
+        # wipe the values of tool_exec_environment_variables (they contain secrets)
+        if agent_schema.tool_exec_environment_variables:
+            agent_schema.tool_exec_environment_variables = {key: "" for key in agent_schema.tool_exec_environment_variables}
+
         if agent_schema.messages:
             for message in agent_schema.messages:
                 message_file_id = self._map_db_to_file_id(message.id, MessageSchema.__id_prefix__)
@@ -650,9 +654,10 @@ class AgentSerializationManager:
                 if agent_data.get("source_ids"):
                     agent_data["source_ids"] = [file_to_db_ids[file_id] for file_id in agent_data["source_ids"]]
 
-                if env_vars:
-                    for var in agent_data["tool_exec_environment_variables"]:
-                        var["value"] = env_vars.get(var["key"], "")
+                if env_vars and agent_data.get("tool_exec_environment_variables"):
+                    # update environment variable values from the provided env_vars dict
+                    for key in agent_data["tool_exec_environment_variables"]:
+                        agent_data["tool_exec_environment_variables"][key] = env_vars.get(key, "")
 
                 # Override project_id if provided
                 if project_id:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR fixes a security issue where `tool_exec_environment_variables` values (containing secrets like API keys and passwords) were being exported in plain text in agent serialization files.
 The fix ensures that secret values are wiped (replaced with empty strings) during export while preserving the variable names/keys. During import, users can provide the actual secret values
via the `env_vars` parameter.

Additionally, this PR fixes a bug in the import logic where `tool_exec_environment_variables` was incorrectly treated as a list of objects instead of a `Dict[str, str]`.

**How to test**
Run the new test cases:
```bash
# Test that secrets are scrubbed during export
python -m pytest tests/test_agent_serialization_v2.py::TestAgentFileExport::test_tool_exec_environment_variables_scrubbing -xvs

# Test that env vars can be provided during import
python -m pytest tests/test_agent_serialization_v2.py::TestAgentFileImport::test_import_with_environment_variables -xvs
```

Expected outcomes:
1. First test should verify that environment variable values are replaced with empty strings during export
2. Second test should verify that new environment variable values can be provided during import and are correctly applied to the imported agent