### PR TITLE
fix: null check on span before log event

### DIFF
--- a/letta/interfaces/anthropic_streaming_interface.py
+++ b/letta/interfaces/anthropic_streaming_interface.py
@@ -227,10 +227,11 @@ class AnthropicStreamingInterface:
             import traceback
 
             logger.error("Error processing stream: %s\n%s", e, traceback.format_exc())
-            ttft_span.add_event(
-                name="stop_reason",
-                attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},
-            )
+            if ttft_span:
+                ttft_span.add_event(
+                    name="stop_reason",
+                    attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},
+                )
             yield LettaStopReason(stop_reason=StopReasonType.error)
             raise e
         finally:

--- a/letta/interfaces/openai_streaming_interface.py
+++ b/letta/interfaces/openai_streaming_interface.py
@@ -167,10 +167,11 @@ class OpenAIStreamingInterface:
             import traceback
 
             logger.error("Error processing stream: %s\n%s", e, traceback.format_exc())
-            ttft_span.add_event(
-                name="stop_reason",
-                attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},
-            )
+            if ttft_span:
+                ttft_span.add_event(
+                    name="stop_reason",
+                    attributes={"stop_reason": StopReasonType.error.value, "error": str(e), "stacktrace": traceback.format_exc()},
+                )
             yield LettaStopReason(stop_reason=StopReasonType.error)
             raise e
         finally:


### PR DESCRIPTION
Stacktrace:
```
Traceback (most recent call last):
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/streaming_response.py", line 238, in _protected_stream_response
    async for chunk in self.body_iterator:
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/streaming_response.py", line 103, in add_keepalive_to_stream
    await reader_task
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/streaming_response.py", line 60, in stream_reader
    async for item in stream_generator:
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/agents/letta_agent_v2.py", line 280, in stream
    async for chunk in response:
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/agents/letta_agent_v2.py", line 494, in _step
    raise e
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/agents/letta_agent_v2.py", line 422, in _step
    raise e
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/agents/letta_agent_v2.py", line 402, in _step
    async for chunk in invocation:
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/adapters/letta_llm_stream_adapter.py", line 80, in invoke_llm
    async for chunk in self.interface.process(stream):  # TODO: add ttft span
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/interfaces/anthropic_streaming_interface.py", line 230, in process
    ttft_span.add_event(
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'add_event'
```