### PR TITLE
feat: handle missing closing bracket for json parse

### DIFF
--- a/letta/interfaces/anthropic_streaming_interface.py
+++ b/letta/interfaces/anthropic_streaming_interface.py
@@ -346,6 +346,10 @@ class AnthropicStreamingInterface:
                 self.accumulated_tool_call_args += delta.partial_json
                 current_parsed = self.json_parser.parse(self.accumulated_tool_call_args)
 
+                # Store the corrected JSON back (fixes Python booleans, missing braces, etc)
+                if current_parsed:
+                    self.accumulated_tool_call_args = json.dumps(current_parsed)
+
                 # Start detecting a difference in inner thoughts
                 previous_inner_thoughts = self.previous_parse.get(INNER_THOUGHTS_KWARG, "")
                 current_inner_thoughts = current_parsed.get(INNER_THOUGHTS_KWARG, "")


### PR DESCRIPTION
Stacktrace:
```
WARNING  Letta.letta.server.rest_api.json_parser:json_parser.py:36 PydanticJSONParser failed: expected value at line 1 column 40 | input_str='{"num_sides": 16, "request_heartbeat": True', falling back to OptimisticJSONParser
ERROR    Letta.letta.server.rest_api.json_parser:json_parser.py:41 Both parsers failed. Pydantic: expected value at line 1 column 40, Optimistic: Expecting value: line 1 column 40 (char 39) | input_str='{"num_sides": 16, "request_heartbeat": True'
ERROR    Letta.letta.interfaces.anthropic_streaming_interface:anthropic_streaming_interface.py:229 Error processing stream: Expecting value: line 1 column 40 (char 39)
Traceback (most recent call last):
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/interfaces/anthropic_streaming_interface.py", line 204, in process
    async for message in self._process_event(event, ttft_span, prev_message_type, message_index):
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/interfaces/anthropic_streaming_interface.py", line 347, in _process_event
    current_parsed = self.json_parser.parse(self.accumulated_tool_call_args)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 42, in parse
    raise fallback_e
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 39, in parse
    return fallback_parser.parse(input_str)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 89, in parse
    data, reminding = self._parse_any(input_str, decode_error)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 104, in _parse_any
    return parser(input_str, decode_error)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 157, in _parse_object
    value, input_str = self._parse_any(input_str, decode_error)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 103, in _parse_any
    raise decode_error
  File "/home/ci-runner/actions-runner/_work/letta/letta/letta/server/rest_api/json_parser.py", line 87, in parse
    return json.loads(input_str)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 40 (char 39)
```