### PR TITLE
fix: 4o mini assistant streaming error

### DIFF
--- a/letta/interfaces/openai_streaming_interface.py
+++ b/letta/interfaces/openai_streaming_interface.py
@@ -278,6 +278,8 @@ class OpenAIStreamingInterface:
                                     self.prev_assistant_message_id = self.function_id_buffer
                                 # Reset message reader at the start of a new send_message stream
                                 self.assistant_message_json_reader.reset()
+                                self.assistant_message_json_reader.in_message = True
+                                self.assistant_message_json_reader.message_started = True
 
                             else:
                                 if prev_message_type and prev_message_type != "tool_call_message":


### PR DESCRIPTION
## This PR

**Implementation Details:**

Fix a critical bug in the assistant message JSON parser where it incorrectly returns nothing (None) every time. The issue occurs because the parser only enters `assistant_message_json_reader.process_json_chunk` after the message has started, but the flag that tracks this state never flips to the correct value, resulting in None being returned consistently.

**Testing:**

```
(letta) caren@mac letta % uv run pytest -s -vv tests/integration_test_send_message.py::test_token_streaming_greeting_with_assistant_message -k "gpt-4o-mini0"


NEW CHUNK:

ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='message', name=None), type=None)

self.last_flushed_function_name: None

NEW CHUNK:

ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='":"', name=None), type=None)

self.last_flushed_function_name: None

NEW CHUNK:

ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='Team', name=None), type=None)

self.last_flushed_function_name: send_message
```

**Notes:**

This is a high-priority fix for a bug that is preventing assistant messages from returning in production when `use_assistant_message` is set to `True`. The issue doesn't affect the ADE (Agent Development Environment) because that frontend doesn't use this flag. The root cause was in the state tracking logic of the JSON parser, which failed to properly identify when processing should begin.

Not entirely sure what the implications are of adding this patch, there is probably a better fix for the underlying root cause.