### PR TITLE
feat: rename provider key check method in api

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -872,7 +872,7 @@ paths:
         - providers
       x-fern-sdk-method-name: modify
   /v1/providers/check:
-    get:
+    post:
       x-fern-sdk-group-name:
         - providers
       x-fern-sdk-method-name: check


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename the `client.providers.check_provider` API endpoint to `client.providers.check`.

**Notes:**

The existing override wasn't working because the method name did not match the definition.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.