### PR TITLE
feat: add pagination to client.tags.list endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/tags.py
+++ b/letta/server/rest_api/routers/v1/tags.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Header, Query
 
@@ -13,15 +13,26 @@ router = APIRouter(prefix="/tags", tags=["tag", "admin"])
 
 @router.get("/", tags=["admin"], response_model=List[str], operation_id="list_tags")
 async def list_tags(
-    after: Optional[str] = Query(None),
-    limit: Optional[int] = Query(50),
+    before: Optional[str] = Query(
+        None, description="Tag cursor for pagination. Returns tags that come before this tag in the specified sort order"
+    ),
+    after: Optional[str] = Query(
+        None, description="Tag cursor for pagination. Returns tags that come after this tag in the specified sort order"
+    ),
+    limit: Optional[int] = Query(50, description="Maximum number of tags to return"),
+    order: Literal["asc", "desc"] = Query(
+        "asc", description="Sort order for tags. 'asc' for alphabetical order, 'desc' for reverse alphabetical order"
+    ),
+    order_by: Literal["name"] = Query("name", description="Field to sort by"),
+    query_text: Optional[str] = Query(None, description="Filter tags by text search"),
     server: "SyncServer" = Depends(get_letta_server),
-    query_text: Optional[str] = Query(None),
     actor_id: Optional[str] = Header(None, alias="user_id"),
 ):
     """
-    Get a list of all tags in the database
+    Get a list of all agent tags in the database.
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
-    tags = await server.agent_manager.list_tags_async(actor=actor, after=after, limit=limit, query_text=query_text)
+    tags = await server.agent_manager.list_tags_async(
+        actor=actor, before=before, after=after, limit=limit, query_text=query_text, ascending=(order == "asc")
+    )
     return tags


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `list_tags` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

The default `order_by` is set to 'name' for alphabetical sorting, unlike other endpoints which typically default to creation timestamp.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.