### PR TITLE
fix: make feedback endpoint use request body not query params

### DIFF
--- a/letta/server/rest_api/routers/v1/steps.py
+++ b/letta/server/rest_api/routers/v1/steps.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query
+from pydantic import BaseModel, Field
 
 from letta.orm.errors import NoResultFound
 from letta.schemas.step import Step
@@ -93,10 +94,14 @@ async def retrieve_step_metrics(
         raise HTTPException(status_code=404, detail="Step metrics not found")
 
 
+class AddFeedbackRequest(BaseModel):
+    feedback: FeedbackType | None = Field(None, description="Whether this feedback is positive or negative")
+
+
 @router.patch("/{step_id}/feedback", response_model=Step, operation_id="add_feedback")
 async def add_feedback(
     step_id: str,
-    feedback: Optional[FeedbackType],
+    feedback: AddFeedbackRequest = Body(...),
     actor_id: Optional[str] = Header(None, alias="user_id"),
     server: SyncServer = Depends(get_letta_server),
 ):


### PR DESCRIPTION
## This PR

**Implementation Details:**

Update the feedback endpoint to use request body instead of query parameters.

**Notes:**

This change is important because the documentation was being generated incorrectly when using query parameters. Using a request body ensures proper documentation generation and better represents the API design.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.