### PR TITLE
feat: rename steps metrics endpoint

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -892,6 +892,12 @@ paths:
         - steps
         - feedback
       x-fern-sdk-method-name: create
+  /v1/steps/{step_id}/metrics:
+    get:
+      x-fern-sdk-group-name:
+        - steps
+        - metrics
+      x-fern-sdk-method-name: retrieve
   /v1/identities/:
     get:
       x-fern-sdk-group-name:


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename `client.steps.retrieve_step_metrics` to `client.steps.metrics.retrieve`.

**Notes:**

Considering consolidating the telemetry endpoints together but will revisit later.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.