### PR TITLE
fix: re-add telemetry route for backwards compatibility

### DIFF
--- a/letta/server/rest_api/routers/v1/__init__.py
+++ b/letta/server/rest_api/routers/v1/__init__.py
@@ -15,6 +15,7 @@ from letta.server.rest_api.routers.v1.sandbox_configs import router as sandbox_c
 from letta.server.rest_api.routers.v1.sources import router as sources_router
 from letta.server.rest_api.routers.v1.steps import router as steps_router
 from letta.server.rest_api.routers.v1.tags import router as tags_router
+from letta.server.rest_api.routers.v1.telemetry import router as telemetry_router
 from letta.server.rest_api.routers.v1.tools import router as tools_router
 from letta.server.rest_api.routers.v1.voice import router as voice_router
 
@@ -35,6 +36,7 @@ ROUTERS = [
     runs_router,
     steps_router,
     tags_router,
+    telemetry_router,
     messages_router,
     voice_router,
     embeddings_router,

--- a/letta/server/rest_api/routers/v1/telemetry.py
+++ b/letta/server/rest_api/routers/v1/telemetry.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header
+
+from letta.schemas.provider_trace import ProviderTrace
+from letta.server.rest_api.utils import get_letta_server
+from letta.server.server import SyncServer
+from letta.settings import settings
+
+router = APIRouter(prefix="/telemetry", tags=["telemetry"])
+
+
+@router.get("/{step_id}", response_model=Optional[ProviderTrace], operation_id="retrieve_provider_trace")
+async def retrieve_provider_trace_by_step_id(
+    step_id: str,
+    server: SyncServer = Depends(get_letta_server),
+    actor_id: str | None = Header(None, alias="user_id"),  # Extract user_id from header, default to None if not present
+):
+    provider_trace = None
+    if settings.track_provider_trace:
+        try:
+            provider_trace = await server.telemetry_manager.get_provider_trace_by_step_id_async(
+                step_id=step_id, actor=await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
+            )
+        except:
+            pass
+
+    return provider_trace


### PR DESCRIPTION
Actually, we shouldn't delete old paths yet because it will break functionality for older api versions. We should optimize for graceful deprecation where possible.
