### PR TITLE
feat: rename message preview endpoint

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -556,7 +556,7 @@ paths:
       x-fern-sdk-group-name:
         - agents
         - messages
-      x-fern-sdk-method-name: preview_raw_payload
+      x-fern-sdk-method-name: preview
   /v1/agents/messages/search:
     post:
       x-fern-sdk-group-name:


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename message preview endpoint from `client.agents.messages.preview_raw_payload` to `client.agents.messages.preview`.

**Notes:**

The functionality is well documented in the title and docstring, so we can simplify the endpoint name. We want all our APIs to be simple, not verbose.


## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.