### PR TITLE
feat: add pagination to providers endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/providers.py
+++ b/letta/server/rest_api/routers/v1/providers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
 from fastapi.responses import JSONResponse
@@ -17,20 +17,31 @@ router = APIRouter(prefix="/providers", tags=["providers"])
 
 @router.get("/", response_model=List[Provider], operation_id="list_providers")
 async def list_providers(
-    name: Optional[str] = Query(None),
-    provider_type: Optional[ProviderType] = Query(None),
-    after: Optional[str] = Query(None),
-    limit: Optional[int] = Query(50),
+    before: Optional[str] = Query(
+        None,
+        description="Provider ID cursor for pagination. Returns providers that come before this provider ID in the specified sort order",
+    ),
+    after: Optional[str] = Query(
+        None,
+        description="Provider ID cursor for pagination. Returns providers that come after this provider ID in the specified sort order",
+    ),
+    limit: Optional[int] = Query(50, description="Maximum number of providers to return"),
+    order: Literal["asc", "desc"] = Query(
+        "desc", description="Sort order for providers by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
+    name: Optional[str] = Query(None, description="Filter providers by name"),
+    provider_type: Optional[ProviderType] = Query(None, description="Filter providers by type"),
     actor_id: Optional[str] = Header(None, alias="user_id"),
     server: "SyncServer" = Depends(get_letta_server),
 ):
     """
-    Get a list of all custom providers.
+    Get a list of all custom providers with pagination support.
     """
     try:
         actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
         providers = await server.provider_manager.list_providers_async(
-            after=after, limit=limit, actor=actor, name=name, provider_type=provider_type
+            before=before, after=after, limit=limit, actor=actor, name=name, provider_type=provider_type, ascending=(order == "asc")
         )
     except HTTPException:
         raise

--- a/letta/services/provider_manager.py
+++ b/letta/services/provider_manager.py
@@ -154,10 +154,14 @@ class ProviderManager:
         actor: PydanticUser,
         name: Optional[str] = None,
         provider_type: Optional[ProviderType] = None,
+        before: Optional[str] = None,
         after: Optional[str] = None,
         limit: Optional[int] = 50,
+        ascending: bool = False,
     ) -> List[PydanticProvider]:
-        """List all providers with optional pagination."""
+        """
+        List all providers with pagination support.
+        """
         filter_kwargs = {}
         if name:
             filter_kwargs["name"] = name
@@ -166,9 +170,11 @@ class ProviderManager:
         async with db_registry.async_session() as session:
             providers = await ProviderModel.list_async(
                 db_session=session,
+                before=before,
                 after=after,
                 limit=limit,
                 actor=actor,
+                ascending=ascending,
                 check_is_deleted=True,
                 **filter_kwargs,
             )


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `list_tags` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.


## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.