### PR TITLE
feat: add pagination to steps endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/steps.py
+++ b/letta/server/rest_api/routers/v1/steps.py
@@ -21,7 +21,10 @@ async def list_steps(
     before: Optional[str] = Query(None, description="Return steps before this step ID"),
     after: Optional[str] = Query(None, description="Return steps after this step ID"),
     limit: Optional[int] = Query(50, description="Maximum number of steps to return"),
-    order: Optional[str] = Query("desc", description="Sort order (asc or desc)"),
+    order: Literal["asc", "desc"] = Query(
+        "desc", description="Sort order for steps by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
     start_date: Optional[str] = Query(None, description='Return steps after this ISO datetime (e.g. "2025-01-29T15:01:19-08:00")'),
     end_date: Optional[str] = Query(None, description='Return steps before this ISO datetime (e.g. "2025-01-29T15:01:19-08:00")'),
     model: Optional[str] = Query(None, description="Filter by the name of the model used for the step"),
@@ -39,7 +42,6 @@ async def list_steps(
 ):
     """
     List steps with optional pagination and date filters.
-    Dates should be provided in ISO 8601 format (e.g. 2025-01-29T15:01:19-08:00)
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
 
@@ -54,7 +56,7 @@ async def list_steps(
         start_date=start_dt,
         end_date=end_dt,
         limit=limit,
-        order=order,
+        order=(order == "asc"),
         model=model,
         agent_id=agent_id,
         trace_ids=trace_ids,


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.steps.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.