### PR TITLE
feat: add pagination to identities endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/identities.py
+++ b/letta/server/rest_api/routers/v1/identities.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query
 
@@ -18,9 +18,19 @@ async def list_identities(
     project_id: Optional[str] = Query(None),
     identifier_key: Optional[str] = Query(None),
     identity_type: Optional[IdentityType] = Query(None),
-    before: Optional[str] = Query(None),
-    after: Optional[str] = Query(None),
-    limit: Optional[int] = Query(50),
+    before: Optional[str] = Query(
+        None,
+        description="Identity ID cursor for pagination. Returns identities that come before this identity ID in the specified sort order",
+    ),
+    after: Optional[str] = Query(
+        None,
+        description="Identity ID cursor for pagination. Returns identities that come after this identity ID in the specified sort order",
+    ),
+    limit: Optional[int] = Query(50, description="Maximum number of identities to return"),
+    order: Literal["asc", "desc"] = Query(
+        "desc", description="Sort order for identities by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
     server: "SyncServer" = Depends(get_letta_server),
     actor_id: Optional[str] = Header(None, alias="user_id"),  # Extract user_id from header, default to None if not present
 ):
@@ -38,6 +48,7 @@ async def list_identities(
             before=before,
             after=after,
             limit=limit,
+            ascending=(order == "asc"),
             actor=actor,
         )
     except HTTPException:

--- a/letta/services/identity_manager.py
+++ b/letta/services/identity_manager.py
@@ -35,6 +35,7 @@ class IdentityManager:
         before: Optional[str] = None,
         after: Optional[str] = None,
         limit: Optional[int] = 50,
+        ascending: bool = False,
         actor: PydanticUser = None,
     ) -> list[PydanticIdentity]:
         async with db_registry.async_session() as session:
@@ -51,6 +52,7 @@ class IdentityManager:
                 before=before,
                 after=after,
                 limit=limit,
+                ascending=ascending,
                 **filters,
             )
             return [identity.to_pydantic() for identity in identities]


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.identities.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.