### PR TITLE
feat: add pagination to blocks endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/blocks.py
+++ b/letta/server/rest_api/routers/v1/blocks.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query
 
@@ -26,12 +26,16 @@ async def list_blocks(
     limit: Optional[int] = Query(50, description="Number of blocks to return"),
     before: Optional[str] = Query(
         None,
-        description="Cursor for pagination. If provided, returns blocks before this cursor.",
+        description="Block ID cursor for pagination. Returns blocks that come before this block ID in the specified sort order",
     ),
     after: Optional[str] = Query(
         None,
-        description="Cursor for pagination. If provided, returns blocks after this cursor.",
+        description="Block ID cursor for pagination. Returns blocks that come after this block ID in the specified sort order",
     ),
+    order: Literal["asc", "desc"] = Query(
+        "asc", description="Sort order for blocks by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
     label_search: Optional[str] = Query(
         None,
         description=("Search blocks by label. If provided, returns blocks that match this label. This is a full-text search on labels."),
@@ -94,6 +98,7 @@ async def list_blocks(
         connected_to_agents_count_eq=connected_to_agents_count_eq,
         limit=limit,
         after=after,
+        ascending=(order == "asc"),
         show_hidden_blocks=show_hidden_blocks,
     )
 


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.blocks.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.