### PR TITLE
feat: add pagination to groups endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/groups.py
+++ b/letta/server/rest_api/routers/v1/groups.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Literal, Optional
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
 from fastapi.responses import JSONResponse
@@ -21,9 +21,17 @@ async def list_groups(
     server: "SyncServer" = Depends(get_letta_server),
     actor_id: Optional[str] = Header(None, alias="user_id"),
     manager_type: Optional[ManagerType] = Query(None, description="Search groups by manager type"),
-    before: Optional[str] = Query(None, description="Cursor for pagination"),
-    after: Optional[str] = Query(None, description="Cursor for pagination"),
-    limit: Optional[int] = Query(None, description="Limit for pagination"),
+    before: Optional[str] = Query(
+        None, description="Group ID cursor for pagination. Returns groups that come before this group ID in the specified sort order"
+    ),
+    after: Optional[str] = Query(
+        None, description="Group ID cursor for pagination. Returns groups that come after this group ID in the specified sort order"
+    ),
+    limit: Optional[int] = Query(50, description="Maximum number of groups to return"),
+    order: Literal["asc", "desc"] = Query(
+        "asc", description="Sort order for groups by creation time. 'asc' for oldest first, 'desc' for newest first"
+    ),
+    order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
     project_id: Optional[str] = Query(None, description="Search groups by project id"),
     show_hidden_groups: bool | None = Query(
         False,
@@ -42,6 +50,7 @@ async def list_groups(
         before=before,
         after=after,
         limit=limit,
+        ascending=(order == "asc"),
         show_hidden_groups=show_hidden_groups,
     )
 

--- a/letta/services/group_manager.py
+++ b/letta/services/group_manager.py
@@ -29,6 +29,7 @@ class GroupManager:
         before: Optional[str] = None,
         after: Optional[str] = None,
         limit: Optional[int] = 50,
+        ascending: bool = True,
         show_hidden_groups: Optional[bool] = None,
     ) -> list[PydanticGroup]:
         async with db_registry.async_session() as session:
@@ -50,7 +51,7 @@ class GroupManager:
                 query = query.where((GroupModel.hidden.is_(None)) | (GroupModel.hidden == False))
 
             # Apply pagination
-            query = await _apply_group_pagination_async(query, before, after, session, ascending=True)
+            query = await _apply_group_pagination_async(query, before, after, session, ascending=ascending)
 
             if limit:
                 query = query.limit(limit)


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.groups.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.