### PR TITLE
fix: Fix leaky opens

### DIFF
--- a/.github/scripts/model-sweep/model_sweep.py
+++ b/.github/scripts/model-sweep/model_sweep.py
@@ -36,7 +36,8 @@ from letta.schemas.llm_config import LLMConfig
 
 def get_llm_config(filename: str, llm_config_dir: str = "tests/configs/llm_model_configs") -> LLMConfig:
     filename = os.path.join(llm_config_dir, filename)
-    config_data = json.load(open(filename, "r"))
+    with open(filename, "r") as f:
+        config_data = json.load(f)
     llm_config = LLMConfig(**config_data)
     return llm_config
 

--- a/examples/files/main.py
+++ b/examples/files/main.py
@@ -66,14 +66,13 @@ except Exception as e:
 
 # 1. From an existing file
 # "rb" means "read binary"
-file = open("example-on-disk.txt", "rb")
-
-# Upload the file to the folder
-file = client.folders.files.upload(
-    folder_id=folder_id,
-    file=file,
-    duplicate_handling="skip"
-)
+with open("example-on-disk.txt", "rb") as f:
+    # Upload the file to the folder
+    file = client.folders.files.upload(
+        folder_id=folder_id,
+        file=f,
+        duplicate_handling="skip"
+    )
 
 # 2. From a string by encoding it into a base64 string
 import io
@@ -111,11 +110,12 @@ if not os.path.exists("memgpt.pdf"):
         f.write(response.content)
 
 # Upload the PDF to the folder
-file = client.folders.files.upload(
-    folder_id=folder_id,
-    file=open("memgpt.pdf", "rb"),
-    duplicate_handling="skip"
-)
+with open("memgpt.pdf", "rb") as f:
+    file = client.folders.files.upload(
+        folder_id=folder_id,
+        file=f,
+        duplicate_handling="skip"
+    )
 
 #
 # Now we need to create an agent that can use this folder

--- a/examples/sleeptime/sleeptime_source_example.py
+++ b/examples/sleeptime/sleeptime_source_example.py
@@ -39,10 +39,11 @@ client.agents.sources.attach(
 )
 
 # upload a file: this will trigger processing
-job = client.sources.files.upload(
-    file=open("handbook.pdf", "rb"),
-    source_id=source.id
-)
+with open("handbook.pdf", "rb") as f:
+    job = client.sources.files.upload(
+        file=f,
+        source_id=source.id
+    )
 
 time.sleep(2)
 

--- a/fern/examples/data_sources.py
+++ b/fern/examples/data_sources.py
@@ -25,7 +25,8 @@ with open("dummy.txt", "w") as f:
     f.write("Remember that the user is a redhead")
 
 # upload a file into the source
-job = client.sources.files.upload(source_id=source.id, file=open("dummy.txt", "rb"))
+with open("dummy.txt", "rb") as f:
+    job = client.sources.files.upload(source_id=source.id, file=f)
 
 # wait until the job is completed
 while True:

--- a/letta/utils.py
+++ b/letta/utils.py
@@ -941,7 +941,8 @@ def get_human_text(name: str, enforce_limit=True):
     for file_path in list_human_files():
         file = os.path.basename(file_path)
         if f"{name}.txt" == file or name == file:
-            human_text = open(file_path, encoding="utf-8").read().strip()
+            with open(file_path, encoding="utf-8") as f:
+                human_text = f.read().strip()
             if enforce_limit and len(human_text) > CORE_MEMORY_HUMAN_CHAR_LIMIT:
                 raise ValueError(f"Contents of {name}.txt is over the character limit ({len(human_text)} > {CORE_MEMORY_HUMAN_CHAR_LIMIT})")
             return human_text
@@ -953,7 +954,8 @@ def get_persona_text(name: str, enforce_limit=True):
     for file_path in list_persona_files():
         file = os.path.basename(file_path)
         if f"{name}.txt" == file or name == file:
-            persona_text = open(file_path, encoding="utf-8").read().strip()
+            with open(file_path, encoding="utf-8") as f:
+                persona_text = f.read().strip()
             if enforce_limit and len(persona_text) > CORE_MEMORY_PERSONA_CHAR_LIMIT:
                 raise ValueError(
                     f"Contents of {name}.txt is over the character limit ({len(persona_text)} > {CORE_MEMORY_PERSONA_CHAR_LIMIT})"

--- a/paper_experiments/doc_qa_task/doc_qa.py
+++ b/paper_experiments/doc_qa_task/doc_qa.py
@@ -256,7 +256,8 @@ def run_docqa_task(
     print("Results file:", filename)
 
     if os.path.exists(filename):
-        all_response_data = json.load(open(filename, "r"))
+        with open(filename, "r") as f:
+            all_response_data = json.load(f)
     else:
         all_response_data = []
 

--- a/paper_experiments/doc_qa_task/llm_judge_doc_qa.py
+++ b/paper_experiments/doc_qa_task/llm_judge_doc_qa.py
@@ -86,7 +86,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # load data
-    data = json.load(open(args.file))
+    with open(args.file, "r") as f:
+        data = json.load(f)
 
     # counters
     correct = 0
@@ -149,9 +150,10 @@ if __name__ == "__main__":
         total += 1
 
     # Dump aggregated results
-    json.dump(
-        {"accuracy": correct / total, "total": total, "results": results},
-        open(f"results_{model}_{num_docs}_{baseline}.json", "w"),
-        indent=4,
-    )
+    with open(f"results_{model}_{num_docs}_{baseline}.json", "w") as f:
+        json.dump(
+            {"accuracy": correct / total, "total": total, "results": results},
+            f,
+            indent=4,
+        )
     print(correct / total)

--- a/tests/helpers/endpoints_helper.py
+++ b/tests/helpers/endpoints_helper.py
@@ -50,9 +50,11 @@ def setup_agent(
     include_base_tools: bool = True,
     include_base_tool_rules: bool = True,
 ) -> AgentState:
-    config_data = json.load(open(filename, "r"))
+    with open(filename, "r") as f:
+        config_data = json.load(f)
     llm_config = LLMConfig(**config_data)
-    embedding_config = EmbeddingConfig(**json.load(open(EMBEDDING_CONFIG_PATH)))
+    with open(EMBEDDING_CONFIG_PATH, "r") as f:
+        embedding_config = EmbeddingConfig(**json.load(f))
 
     # setup config
     config = LettaConfig()
@@ -93,7 +95,8 @@ def setup_agent(
 
 async def run_embedding_endpoint(filename, actor=None):
     # load JSON file
-    config_data = json.load(open(filename, "r"))
+    with open(filename, "r") as f:
+        config_data = json.load(f)
     print(config_data)
     embedding_config = EmbeddingConfig(**config_data)
 

--- a/tests/integration_test_builtin_tools.py
+++ b/tests/integration_test_builtin_tools.py
@@ -97,7 +97,8 @@ def agent_state(client: Letta) -> AgentState:
 
 def get_llm_config(filename: str, llm_config_dir: str = "tests/configs/llm_model_configs") -> LLMConfig:
     filename = os.path.join(llm_config_dir, filename)
-    config_data = json.load(open(filename, "r"))
+    with open(filename, "r") as f:
+        config_data = json.load(f)
     llm_config = LLMConfig(**config_data)
     return llm_config
 

--- a/tests/integration_test_send_message.py
+++ b/tests/integration_test_send_message.py
@@ -47,7 +47,8 @@ logger = get_logger(__name__)
 
 def get_llm_config(filename: str, llm_config_dir: str = "tests/configs/llm_model_configs") -> LLMConfig:
     filename = os.path.join(llm_config_dir, filename)
-    config_data = json.load(open(filename, "r"))
+    with open(filename, "r") as f:
+        config_data = json.load(f)
     llm_config = LLMConfig(**config_data)
     return llm_config
 

--- a/tests/integration_test_summarizer.py
+++ b/tests/integration_test_summarizer.py
@@ -269,9 +269,11 @@ def test_summarizer(config_filename, server, default_user):
     agent_name = str(uuid.uuid5(namespace, f"integration-test-summarizer-{config_filename}"))
 
     # Load configs
-    config_data = json.load(open(os.path.join(LLM_CONFIG_DIR, config_filename)))
+    with open(os.path.join(LLM_CONFIG_DIR, config_filename), "r") as f:
+        config_data = json.load(f)
     llm_config = LLMConfig(**config_data)
-    embedding_config = EmbeddingConfig(**json.load(open(EMBEDDING_CONFIG_PATH)))
+    with open(EMBEDDING_CONFIG_PATH, "r") as f:
+        embedding_config = EmbeddingConfig(**json.load(f))
 
     # Ensure cleanup
     cleanup(server=server, agent_uuid=agent_name, actor=default_user)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -18,9 +18,11 @@ included_files = [
 ]
 config_dir = "tests/configs/embedding_model_configs"
 config_files = glob.glob(os.path.join(config_dir, "*.json"))
-embedding_configs = [
-    EmbeddingConfig(**json.load(open(config_file))) for config_file in config_files if config_file.split("/")[-1] in included_files
-]
+embedding_configs = []
+for config_file in config_files:
+    if config_file.split("/")[-1] in included_files:
+        with open(config_file, "r") as f:
+            embedding_configs.append(EmbeddingConfig(**json.load(f)))
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix leaky `open` calls (never gets cleaned up, not within a context manager). This can cause file descriptor limit issues on the OS.

Most critical functions are `get_human_text` and `get_persona_text` in `letta/utils.py`.