### PR TITLE
feat: rename folders agents endpoint

### DIFF
--- a/fern/openapi-overrides.yml
+++ b/fern/openapi-overrides.yml
@@ -214,6 +214,12 @@ paths:
         - folders
         - files
       x-fern-sdk-method-name: delete
+  /v1/folders/{folder_id}/agents:
+    get:
+      x-fern-sdk-group-name:
+        - folders
+        - agents
+      x-fern-sdk-method-name: list
   /v1/agents/:
     get:
       x-fern-sdk-group-name:

--- a/letta/server/rest_api/routers/v1/folders.py
+++ b/letta/server/rest_api/routers/v1/folders.py
@@ -342,8 +342,8 @@ async def upload_file_to_folder(
     return file_metadata
 
 
-@router.get("/{folder_id}/agents", response_model=List[str], operation_id="get_agents_for_folder")
-async def get_agents_for_folder(
+@router.get("/{folder_id}/agents", response_model=List[str], operation_id="list_agents_for_folder")
+async def list_agents_for_folder(
     folder_id: str,
     server: SyncServer = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),


### PR DESCRIPTION
## This PR

**Implementation Details:**

Rename `client.folders.get_agents_for_folder` to `client.folders.agents.list`.

**Notes:**

This change should be backwards compatible since the underlying url of the endpoint doesn't change.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.