### PR TITLE
feat: deprecate get folder by name endpoint

### DIFF
--- a/letta/server/rest_api/routers/v1/folders.py
+++ b/letta/server/rest_api/routers/v1/folders.py
@@ -75,14 +75,17 @@ async def retrieve_folder(
     return folder
 
 
-@router.get("/name/{folder_name}", response_model=str, operation_id="get_folder_id_by_name")
-async def get_folder_id_by_name(
+@router.get("/name/{folder_name}", response_model=str, operation_id="get_folder_by_name", deprecated=True)
+async def get_folder_by_name(
     folder_name: str,
     server: "SyncServer" = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),
 ):
     """
-    Get a folder by name
+    **Deprecated**: Please use the list endpoint `/GET v1/folders?name=` instead.
+
+
+    Get a folder by name.
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
 
@@ -126,6 +129,7 @@ async def list_folders(
         "asc", description="Sort order for folders by creation time. 'asc' for oldest first, 'desc' for newest first"
     ),
     order_by: Literal["created_at"] = Query("created_at", description="Field to sort by"),
+    name: Optional[str] = Query(None, description="Folder name to filter by"),
     server: "SyncServer" = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),
 ):
@@ -133,7 +137,9 @@ async def list_folders(
     List all data folders created by a user.
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
-    return await server.source_manager.list_sources(actor=actor, before=before, after=after, limit=limit, ascending=(order == "asc"))
+    return await server.source_manager.list_sources(
+        actor=actor, before=before, after=after, limit=limit, ascending=(order == "asc"), name=name
+    )
 
 
 @router.post("/", response_model=Folder, operation_id="create_folder")

--- a/letta/services/source_manager.py
+++ b/letta/services/source_manager.py
@@ -236,6 +236,7 @@ class SourceManager:
         after: Optional[str] = None,
         limit: Optional[int] = 50,
         ascending: bool = True,
+        name: Optional[str] = None,
         **kwargs,
     ) -> List[PydanticSource]:
         """List all sources with optional pagination."""
@@ -247,6 +248,7 @@ class SourceManager:
                 limit=limit,
                 ascending=ascending,
                 organization_id=actor.organization_id,
+                name=name,
                 **kwargs,
             )
             return [source.to_pydantic() for source in sources]


### PR DESCRIPTION
## This PR

**Implementation Details:**

Mark `client.folders.retrieve_by_name` endpoint as deprecated since it doesn't follow rest convention. Instead we add a name parameter to the folders list endpoint for filtering so users can easily swap to the new endpoint.

**Notes:**

Still keep around the old endpoint for backwards compatibility.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.