### PR TITLE
feat: add pagination to folders files endpoint

### DIFF
--- a/letta/services/file_manager.py
+++ b/letta/services/file_manager.py
@@ -404,8 +404,10 @@ class FileManager:
         self,
         source_id: str,
         actor: PydanticUser,
+        before: Optional[str] = None,
         after: Optional[str] = None,
         limit: Optional[int] = 50,
+        ascending: Optional[bool] = True,
         include_content: bool = False,
         strip_directory_prefix: bool = False,
         check_status_updates: bool = False,
@@ -415,8 +417,10 @@ class FileManager:
         Args:
             source_id: Source to list files from
             actor: User performing the request
+            before: Before filter
             after: Pagination cursor
             limit: Maximum number of files to return
+            ascending: Sort by ascending or descending order
             include_content: Whether to include file content
             strip_directory_prefix: Whether to strip directory prefix from filenames
             check_status_updates: Whether to check and update status for timeout and embedding completion
@@ -429,8 +433,10 @@ class FileManager:
 
             files = await FileMetadataModel.list_async(
                 db_session=session,
+                before=before,
                 after=after,
                 limit=limit,
+                ascending=ascending,
                 organization_id=actor.organization_id,
                 source_id=source_id,
                 query_options=options,


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add pagination to the `client.folders.files.list` endpoint with `before`, `after`, `limit`, `order`, and `order_by` parameters.

**Notes:**

While `order_by` is not currently used, adding to document the default behavior, and keep consistent with other endpoints.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.