### PR TITLE
feat: add active filter to jobs endpoint and deprecate list active jobs

### DIFF
--- a/letta/server/rest_api/routers/v1/jobs.py
+++ b/letta/server/rest_api/routers/v1/jobs.py
@@ -19,18 +19,23 @@ async def list_jobs(
     before: Optional[str] = Query(None, description="Cursor for pagination"),
     after: Optional[str] = Query(None, description="Cursor for pagination"),
     limit: Optional[int] = Query(50, description="Limit for pagination"),
+    active: bool = Query(False, description="Filter for active jobs."),
     ascending: bool = Query(True, description="Whether to sort jobs oldest to newest (True, default) or newest to oldest (False)"),
     headers: HeaderParams = Depends(get_headers),
 ):
     """
     List all jobs.
-    TODO (cliandy): implementation for pagination
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=headers.actor_id)
+
+    statuses = None
+    if active:
+        statuses = [JobStatus.created, JobStatus.running]
 
     # TODO: add filtering by status
     return await server.job_manager.list_jobs_async(
         actor=actor,
+        statuses=statuses,
         source_id=source_id,
         before=before,
         after=after,
@@ -39,7 +44,7 @@ async def list_jobs(
     )
 
 
-@router.get("/active", response_model=List[Job], operation_id="list_active_jobs")
+@router.get("/active", response_model=List[Job], operation_id="list_active_jobs", deprecated=True)
 async def list_active_jobs(
     server: "SyncServer" = Depends(get_letta_server),
     headers: HeaderParams = Depends(get_headers),


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add new `active` filter to `client.jobs.list` endpoint so that we can consolidate between multiple list endpoints. This PR also deprecates the separate `client.jobs.list_active` endpoint.

**Notes:**

Keeping around the old endpoint so that this is considered a soft deprecation - don't want to break old client versions.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.