### PR TITLE
feat: support for models that do not allow `None` content

### DIFF
--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -91,7 +91,7 @@ def supports_parallel_tool_calling(model: str) -> bool:
         return False
     else:
         return True
-    
+
 
 # TODO move into LLMConfig as a field?
 def supports_structured_output(llm_config: LLMConfig) -> bool:
@@ -217,7 +217,6 @@ class OpenAIClient(LLMClientBase):
                 tool_choice = ToolFunctionChoice(type="function", function=ToolFunctionChoiceFunctionCall(name=force_tool_call))
             
         if not supports_content_none(llm_config):
-            # map None to empty string
             for message in openai_message_list:
                 if message.content is None:
                     message.content = ""

--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -91,7 +91,7 @@ def supports_parallel_tool_calling(model: str) -> bool:
         return False
     else:
         return True
-
+    
 
 # TODO move into LLMConfig as a field?
 def supports_structured_output(llm_config: LLMConfig) -> bool:
@@ -115,6 +115,12 @@ def requires_auto_tool_choice(llm_config: LLMConfig) -> bool:
     if llm_config.compatibility_type == "mlx":
         return True
     return False
+
+def supports_content_none(llm_config: LLMConfig) -> bool:
+    """Certain providers don't support the content None."""
+    if llm_config.model and "gpt-oss" in llm_config.model:
+        return False
+    return True
 
 
 class OpenAIClient(LLMClientBase):
@@ -209,6 +215,12 @@ class OpenAIClient(LLMClientBase):
 
             if force_tool_call is not None:
                 tool_choice = ToolFunctionChoice(type="function", function=ToolFunctionChoiceFunctionCall(name=force_tool_call))
+            
+        if not supports_content_none(llm_config):
+            # map None to empty string
+            for message in openai_message_list:
+                if message.content is None:
+                    message.content = ""
 
         data = ChatCompletionRequest(
             model=model,


### PR DESCRIPTION
Currently `gpt-oss` series of models are not supported because `AssistantMessage` will translate into tool call send message with `content=None`. This PR replaces the `None` content with empty string.
Other models that use harmony will likely also have this constraint.