### PR TITLE
feat: add active filter to runs endpoint and deprecate list active runs

### DIFF
--- a/letta/server/rest_api/routers/v1/runs.py
+++ b/letta/server/rest_api/routers/v1/runs.py
@@ -36,6 +36,7 @@ def list_runs(
     after: Optional[str] = Query(None, description="Cursor for pagination"),
     before: Optional[str] = Query(None, description="Cursor for pagination"),
     limit: Optional[int] = Query(50, description="Maximum number of runs to return"),
+    active: bool = Query(False, description="Filter for active runs."),
     ascending: bool = Query(
         False,
         description="Whether to sort agents oldest to newest (True) or newest to oldest (False, default)",
@@ -46,11 +47,15 @@ def list_runs(
     List all runs.
     """
     actor = server.user_manager.get_user_or_default(user_id=headers.actor_id)
+    statuses = None
+    if active:
+        statuses = [JobStatus.created, JobStatus.running]
 
     runs = [
         Run.from_job(job)
         for job in server.job_manager.list_jobs(
             actor=actor,
+            statuses=statuses,
             job_type=JobType.RUN,
             limit=limit,
             before=before,
@@ -66,7 +71,7 @@ def list_runs(
     return runs
 
 
-@router.get("/active", response_model=List[Run], operation_id="list_active_runs")
+@router.get("/active", response_model=List[Run], operation_id="list_active_runs", deprecated=True)
 def list_active_runs(
     server: "SyncServer" = Depends(get_letta_server),
     agent_ids: Optional[List[str]] = Query(None, description="The unique identifier of the agent associated with the run."),


### PR DESCRIPTION
## This PR

**Implementation Details:**

Add new `active` filter to `client.runs.list` endpoint so that we can consolidate between multiple list endpoints. This PR also deprecates the separate `client.runs.list_active` endpoint.

**Notes:**

Keeping around the old endpoint so that this is considered a soft deprecation - don't want to break old client versions.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.