### PR TITLE
feat: add new blocks field to agent model and deprecate memory field

### DIFF
--- a/letta/orm/agent.py
+++ b/letta/orm/agent.py
@@ -231,6 +231,7 @@ class Agent(SqlalchemyBase, OrganizationMixin, ProjectMixin, TemplateEntityMixin
             "tools": [],
             "sources": [],
             "memory": Memory(blocks=[]),
+            "blocks": [],
             "identity_ids": [],
             "multi_agent_group": None,
             "tool_exec_environment_variables": [],
@@ -252,6 +253,7 @@ class Agent(SqlalchemyBase, OrganizationMixin, ProjectMixin, TemplateEntityMixin
                 ],
                 agent_type=self.agent_type,
             ),
+            "blocks": lambda: [b.to_pydantic() for b in self.core_memory],
             "identity_ids": lambda: [i.id for i in self.identities],
             "multi_agent_group": lambda: self.multi_agent_group,
             "tool_exec_environment_variables": lambda: self.tool_exec_environment_variables,
@@ -369,6 +371,7 @@ class Agent(SqlalchemyBase, OrganizationMixin, ProjectMixin, TemplateEntityMixin
             ],
             agent_type=self.agent_type,
         )
+        state["blocks"] = [m.to_pydantic() for m in memory]
         state["identity_ids"] = [i.id for i in identities]
         state["multi_agent_group"] = multi_agent_group
         state["tool_exec_environment_variables"] = tool_exec_environment_variables

--- a/letta/schemas/agent.py
+++ b/letta/schemas/agent.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from letta.constants import CORE_MEMORY_LINE_NUMBER_WARNING, DEFAULT_EMBEDDING_CHUNK_SIZE
-from letta.schemas.block import CreateBlock
+from letta.schemas.block import Block, CreateBlock
 from letta.schemas.embedding_config import EmbeddingConfig
 from letta.schemas.enums import AgentType
 from letta.schemas.environment_variables import AgentEnvironmentVariable
@@ -66,7 +66,8 @@ class AgentState(OrmMetadataBase, validate_assignment=True):
     description: Optional[str] = Field(None, description="The description of the agent.")
     metadata: Optional[Dict] = Field(None, description="The metadata of the agent.")
 
-    memory: Memory = Field(..., description="The in-context memory of the agent.")
+    memory: Memory = Field(..., description="The in-context memory of the agent. Deprecated: use `blocks` instead.", deprecated=True)
+    blocks: List[Block] = Field(..., description="The memory blocks used by the agent.")
     tools: List[Tool] = Field(..., description="The tools used by the agent.")
     sources: List[Source] = Field(..., description="The sources used by the agent.")
     tags: List[str] = Field(..., description="The tags associated with the agent.")


### PR DESCRIPTION
## This PR

**Implementation Details:**

The memory object is legacy and now used in our stack and adds a layer of confusion in the API. Deprecating in favor of a new blocks field that is simply a list of blocks, which matches all the other relationship fields in the API.

**Notes:**

This PR only handles adding the field. Will separately address cutting over to the new field in a later change.

## This Project

**Background:**

The SDK Stabilization project is a focused technical initiative to finalize our API surface in preparation for the 1.0 release. This effort addresses inconsistencies, edge cases, and developer pain points to deliver a robust and reliable SDK.

Key objectives include:
1. Standardizing endpoint patterns and parameter structures for consistency
2. Resolving edge cases and unexpected behaviors in the current implementation
3. Strengthening error handling with predictable error codes and useful messages
4. Finalizing type definitions to ensure accurate developer tooling support
5. Documenting clear compatibility guarantees and deprecation policies

This work represents the critical transition from beta to production-ready status, establishing a solid foundation that developers can depend on with confidence. The 1.0 release will mark our commitment to API stability while creating a clean baseline for future enhancements.