### PR TITLE
docs: correct Lovable spelling in documentation

### DIFF
--- a/fern/pages/getting-started/prompts.mdx
+++ b/fern/pages/getting-started/prompts.mdx
@@ -4,7 +4,7 @@ subtitle: Ready-to-go prompts to help AI coding tools build on Letta
 slug: prompts
 ---
 
-Are you developing an application on Letta using [ChatGPT](https://chatgpt.com), [Cursor](https://cursor.com), [Loveable](https://lovable.dev/), or another AI tool?
+Are you developing an application on Letta using [ChatGPT](https://chatgpt.com), [Cursor](https://cursor.com), [Lovable](https://lovable.dev/), or another AI tool?
 Use our pre-made prompts to teach your AI how to use Letta properly.
 
 ## General instructions for the Letta SDKs


### PR DESCRIPTION
## Summary
This PR fixes a typo in the documentation.

## User Feedback  
A user reported that "Lovable" was spelled incorrectly as "Loveable" on https://docs.letta.com/prompts

## Changes
- Fixed spelling: 'Loveable' → 'Lovable' to match the official product name at lovable.dev