### PR TITLE
fix outdated env / VLLM_API_BASE

### DIFF
--- a/compose-vllm.yaml
+++ b/compose-vllm.yaml
@@ -1,13 +1,12 @@
-version: '3.8'
-
 services:
   letta:
     image: letta/letta:latest
+    container_name: letta
+    restart: unless-stopped
     ports:
       - "8283:8283"
     environment:
-      - LETTA_LLM_ENDPOINT=http://vllm:8000
-      - LETTA_LLM_ENDPOINT_TYPE=vllm
+      - VLLM_API_BASE=http://vllm:8000
       - LETTA_LLM_MODEL=${LETTA_LLM_MODEL} # Replace with your model
       - LETTA_LLM_CONTEXT_WINDOW=8192
     depends_on:
@@ -15,6 +14,8 @@ services:
 
   vllm:
     image: vllm/vllm-openai:latest
+    container_name: vllm
+    restart: unless-stopped
     runtime: nvidia
     deploy:
       resources:
@@ -27,9 +28,7 @@ services:
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN}
     volumes:
       - ~/.cache/huggingface:/root/.cache/huggingface
-    ports:
-      - "8000:8000"
     command: >
-      --model ${LETTA_LLM_MODEL} --max_model_len=8000
+      --model ${LETTA_LLM_MODEL} --max_model_len=8192
     # Replace with your model
     ipc: host


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
Fix for https://github.com/letta-ai/letta/issues/2681#issuecomment-3339576114

**How to test**
`docker compose up -d`
`curl -H http://localhost:8283/v1/models/ -s | jq`
```
  {
    "model": "<vllm-model>",
    "model_endpoint_type": "openai",
    "model_endpoint": "http://vllm:8000/v1",
    "provider_name": "vllm",
    "provider_category": "base",
    "model_wrapper": "chatml",
    "context_window": 2048,
    "put_inner_thoughts_in_kwargs": true,
    "handle": "vllm/<vllm-model>",
    "temperature": 0.7,
    "max_tokens": null,
    "enable_reasoner": true,
    "reasoning_effort": null,
    "max_reasoning_tokens": 0,
    "frequency_penalty": null,
    "compatibility_type": null,
    "verbosity": null,
    "tier": null
  }
```

**Have you tested this PR?**
Yup.

**Related issues or PRs**
https://github.com/letta-ai/letta/issues/2681#issuecomment-3339576114

**Is your PR over 500 lines of code?**
Nope.
