### PR TITLE
fix: downgrade fern version from 0.90.0 to 0.83.0

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "letta",
-  "version": "0.90.0"
+  "version": "0.83.0"
 }


### PR DESCRIPTION
## Summary
- Fixed `fern docs dev` failing with `ETARGET` error by downgrading fern version from 0.90.0 to 0.83.0
- Version 0.90.0 doesn't exist on npm yet; 0.83.0 is the latest available version

## Test plan
- [x] Verified `fern docs dev` starts successfully on port 3000
- [x] Confirmed fern-api@0.83.0 is available on npm