### PR TITLE
Dokploy Compose Addition

### DIFF
--- a/.env.full.example
+++ b/.env.full.example
@@ -1,0 +1,86 @@
+##########################################################
+# Example environment variable configurations for Letta
+# Uncomment and set the sections you want to configure.
+##########################################################
+
+########################
+# Database Configuration
+########################
+# LETTA_PG_USER=letta
+# LETTA_PG_PASSWORD=letta
+# LETTA_PG_DB=letta
+# LETTA_PG_PORT=5432
+# LETTA_DB_HOST=letta-db
+# LETTA_PG_URI=postgresql://letta:letta@letta-db:5432/letta
+
+########################
+# Debugging
+########################
+# LETTA_DEBUG=True
+
+########################
+# OpenAI configuration
+########################
+# OPENAI_API_KEY=sk-...
+
+########################
+# Groq configuration
+########################
+# GROQ_API_KEY=
+
+########################
+# Anthropic configuration
+########################
+# ANTHROPIC_API_KEY=
+
+########################
+# Gemini configuration
+########################
+# GEMINI_API_KEY=
+
+########################
+# Ollama configuration
+########################
+# OLLAMA_BASE_URL=http://host.docker.internal:11434
+
+########################
+# Azure OpenAI configuration
+########################
+# AZURE_API_KEY=
+# AZURE_BASE_URL=
+# AZURE_API_VERSION=
+
+########################
+# vLLM configuration
+########################
+# VLLM_API_BASE=http://host.docker.internal:8000
+
+########################
+# OpenLLM configuration
+########################
+# OPENLLM_AUTH_TYPE=
+# OPENLLM_API_KEY=
+
+########################
+# OpenTelemetry/Observability
+########################
+# LETTA_OTEL_EXPORTER_OTLP_ENDPOINT=
+
+########################
+# ClickHouse (optional)
+########################
+# CLICKHOUSE_ENDPOINT=
+# CLICKHOUSE_DATABASE=
+# CLICKHOUSE_USERNAME=
+# CLICKHOUSE_PASSWORD=
+
+########################
+# Sandbox/Volume Mount (optional)
+########################
+# LETTA_SANDBOX_MOUNT_PATH=/absolute/path/to/local/dir
+
+########################
+# Resend Email Example (optional)
+########################
+# RESEND_API_KEY=
+# RESEND_TARGET_EMAIL_ADDRESS=

--- a/dokploy.compose.yml
+++ b/dokploy.compose.yml
@@ -1,0 +1,41 @@
+# Simplified Compose file for Dokploy. No NGINX and no Postgres images as DokPloy handles those. 
+version: '3.8'
+
+services:
+  letta_server:
+    image: letta/letta:latest
+    hostname: letta-server
+    environment:
+      # PostgreSQL Connection
+      - LETTA_PG_URI=postgresql://${LETTA_PG_USER}:${LETTA_PG_PASSWORD}@${LETTA_DB_HOST}:${LETTA_PG_PORT:-5432}/${LETTA_PG_DB}
+      
+      # Letta Configuration
+      - LETTA_DEBUG=True
+      
+      # AI Provider API Keys
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - GROQ_API_KEY=${GROQ_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      
+      # Optional Providers
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL}
+      - AZURE_API_KEY=${AZURE_API_KEY}
+      - AZURE_BASE_URL=${AZURE_BASE_URL}
+      - AZURE_API_VERSION=${AZURE_API_VERSION}
+      - VLLM_API_BASE=${VLLM_API_BASE}
+      - OPENLLM_AUTH_TYPE=${OPENLLM_AUTH_TYPE}
+      - OPENLLM_API_KEY=${OPENLLM_API_KEY}
+      
+      # Observability (Optional)
+      - LETTA_OTEL_EXPORTER_OTLP_ENDPOINT=${LETTA_OTEL_EXPORTER_OTLP_ENDPOINT}
+      - CLICKHOUSE_ENDPOINT=${CLICKHOUSE_ENDPOINT}
+      - CLICKHOUSE_DATABASE=${CLICKHOUSE_DATABASE}
+      - CLICKHOUSE_USERNAME=${CLICKHOUSE_USERNAME}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD}
+    
+    volumes:
+      - letta_config:/root/.letta
+
+volumes:
+  letta_config:


### PR DESCRIPTION
This is a super simple contribution. 

Simplified compose file without nginx and pgvector built in, as dokploy manages the DB separate in the same project and uses Traefik automatically. 

Also made a new .env.example for docker deployment in general as the current one basically only shows the Openai API key entry and not much else. 