### PR TITLE
docs: reorganize navigation structure

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -133,16 +133,6 @@ navigation:
           - page: Agentic Context Engineering
             path: pages/agents/context_engineering.mdx
 
-      - section: Multi-Agent
-        path: pages/agents/multiagent.mdx
-        contents:
-          - page: Custom Multi-Agent Tools
-            path: pages/agents/multiagent_custom.mdx
-          - page: Multi-Agent Shared Memory
-            path: pages/agents/multiagent_memory.mdx
-          - page: Groups
-            path: pages/agents/groups.mdx
-
       - section: Agent Capabilities
         contents:
           - page: Streaming Responses
@@ -190,8 +180,18 @@ navigation:
           - page: Scheduling
             path: pages/agents/scheduling.mdx
 
+      - section: Multi-Agent
+        path: pages/agents/multiagent.mdx
+        contents:
+          - page: Custom Multi-Agent Tools
+            path: pages/agents/multiagent_custom.mdx
+          - page: Multi-Agent Shared Memory
+            path: pages/agents/multiagent_memory.mdx
+
       - section: Experimental
         contents:
+          - page: Groups
+            path: pages/agents/groups.mdx
           - page: Human-in-the-Loop
             path: pages/agents/human_in_the_loop.mdx
           - page: Sleep-time Agents


### PR DESCRIPTION
## Summary
- Move Groups from Multi-Agent section to Experimental section
- Relocate Multi-Agent section to appear after Configuration and before Experimental
- Improves logical grouping of documentation sections