### PR TITLE
fix: prevent false positive in Secret.get_plaintext() for plaintext values (reopening #3070)

### DIFF
--- a/letta/schemas/secret.py
+++ b/letta/schemas/secret.py
@@ -126,6 +126,10 @@ class Secret(BaseModel):
         # Use cached value if available, but only if it looks like plaintext
         # or we're confident we can decrypt it
         if self._plaintext_cache is not None:
+            # If this was explicitly created as plaintext, trust the cache
+            # This prevents false positives from is_encrypted() heuristic
+            if not self.was_encrypted:
+                return self._plaintext_cache
             # If we have a cache but the stored value looks encrypted and we have no key,
             # we should not use the cache
             if CryptoUtils.is_encrypted(self.encrypted_value) and not CryptoUtils.is_encryption_available():


### PR DESCRIPTION
## Update: Repository Recovery

**Note**: A rogue agent erroneously deleted the previous repository, which caused PR #3070 to be closed. This PR restores the fix and addresses the original issue (#3069).

## Problem

When a Secret is created from plaintext (via `from_plaintext()` with `was_encrypted=False`), the `is_encrypted()` heuristic can incorrectly identify long API keys (e.g., OpenAI API keys) as encrypted. This causes `get_plaintext()` to return `None` when no encryption key is available, even though the value was explicitly stored as plaintext.

## Root Cause

The `CryptoUtils.is_encrypted()` method uses a heuristic that checks if a value is base64-decodable and meets minimum encrypted size requirements. Long API keys (164+ characters) can trigger false positives, causing the code to attempt decryption and fail.

## Solution

Check the `was_encrypted` flag before trusting the `is_encrypted()` heuristic. If `was_encrypted=False`, we know the value was explicitly created as plaintext, so we should trust the cached value.

## Changes

- Added early return in `get_plaintext()` when `was_encrypted=False` and cache exists
- This prevents false positives from clearing the cache unnecessarily
- Preserves existing behavior for actually encrypted values

## Testing

This fix resolves the issue where OpenAI API keys stored as plaintext would return `None` from `get_plaintext()` when `LETTA_ENCRYPTION_KEY` was not set.

Fixes #3069
Reopens #3070

