### PR TITLE
feat: add list_embedding_models_async to OpenRouterProvider

### DIFF
--- a/letta/schemas/providers/openrouter.py
+++ b/letta/schemas/providers/openrouter.py
@@ -7,13 +7,9 @@ from letta.log import get_logger
 from letta.schemas.embedding_config import EmbeddingConfig
 from letta.schemas.enums import ProviderCategory, ProviderType
 from letta.schemas.llm_config import LLMConfig
-from letta.schemas.providers.openai import OpenAIProvider
+from letta.schemas.providers.openai import DEFAULT_EMBEDDING_BATCH_SIZE, OpenAIProvider
 
 logger = get_logger(__name__)
-
-# ALLOWED_PREFIXES = {"gpt-4", "gpt-5", "o1", "o3", "o4"}
-# DISALLOWED_KEYWORDS = {"transcribe", "search", "realtime", "tts", "audio", "computer", "o1-mini", "o1-preview", "o1-pro", "chat"}
-# DEFAULT_EMBEDDING_BATCH_SIZE = 1024
 
 
 class OpenRouterProvider(OpenAIProvider):
@@ -49,3 +45,31 @@ class OpenRouterProvider(OpenAIProvider):
             configs.append(config)
 
         return configs
+
+    async def list_embedding_models_async(self) -> list[EmbeddingConfig]:
+        """
+        Return hardcoded OpenRouter embedding models.
+
+        OpenRouter's /models endpoint doesn't list embedding models,
+        but they support OpenAI's embedding models via the /embeddings endpoint.
+        """
+        return [
+            EmbeddingConfig(
+                embedding_model="openai/text-embedding-3-small",
+                embedding_endpoint_type="openai",
+                embedding_endpoint=self.base_url,
+                embedding_dim=1536,
+                embedding_chunk_size=DEFAULT_EMBEDDING_CHUNK_SIZE,
+                handle=self.get_handle("openai/text-embedding-3-small", is_embedding=True),
+                batch_size=DEFAULT_EMBEDDING_BATCH_SIZE,
+            ),
+            EmbeddingConfig(
+                embedding_model="openai/text-embedding-3-large",
+                embedding_endpoint_type="openai",
+                embedding_endpoint=self.base_url,
+                embedding_dim=3072,
+                embedding_chunk_size=DEFAULT_EMBEDDING_CHUNK_SIZE,
+                handle=self.get_handle("openai/text-embedding-3-large", is_embedding=True),
+                batch_size=DEFAULT_EMBEDDING_BATCH_SIZE,
+            ),
+        ]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,6 +13,7 @@ from letta.schemas.providers import (
     GroqProvider,
     OllamaProvider,
     OpenAIProvider,
+    OpenRouterProvider,
     TogetherProvider,
     VLLMProvider,
 )
@@ -152,6 +153,40 @@ async def test_together():
     # embedding_models = provider.list_embedding_models()
     # assert len(embedding_models) > 0
     # assert embedding_models[0].handle == f"{provider.name}/{embedding_models[0].embedding_model}"
+
+
+@pytest.mark.skipif(model_settings.openrouter_api_key is None, reason="Only run if OPENROUTER_API_KEY is set.")
+@pytest.mark.asyncio
+async def test_openrouter():
+    provider = OpenRouterProvider(
+        name="openrouter",
+        api_key=model_settings.openrouter_api_key,
+    )
+    models = await provider.list_llm_models_async()
+    assert len(models) > 0
+    assert models[0].handle.startswith(f"{provider.name}/")
+
+    embedding_models = await provider.list_embedding_models_async()
+    assert len(embedding_models) == 2
+    assert embedding_models[0].embedding_model == "openai/text-embedding-3-small"
+    assert embedding_models[0].embedding_dim == 1536
+    assert embedding_models[1].embedding_model == "openai/text-embedding-3-large"
+    assert embedding_models[1].embedding_dim == 3072
+
+
+@pytest.mark.asyncio
+async def test_openrouter_embedding_models_without_api_key():
+    """Test that OpenRouter embedding models can be listed without making API calls."""
+    provider = OpenRouterProvider(
+        name="openrouter",
+        api_key="fake_key",
+    )
+    embedding_models = await provider.list_embedding_models_async()
+    assert len(embedding_models) == 2
+    assert embedding_models[0].handle == f"{provider.name}/openai/text-embedding-3-small"
+    assert embedding_models[0].embedding_endpoint == "https://openrouter.ai/api/v1"
+    assert embedding_models[0].embedding_endpoint_type == "openai"
+    assert embedding_models[1].handle == f"{provider.name}/openai/text-embedding-3-large"
 
 
 # ===== Local Models =====


### PR DESCRIPTION
## Summary

- Add `list_embedding_models_async()` method to `OpenRouterProvider` class
- Return hardcoded `EmbeddingConfig` objects for OpenAI embedding models supported by OpenRouter
- Add unit tests for the new functionality

## Problem

When using OpenRouter as an LLM provider, Letta cannot discover embedding models because OpenRouter's `/models` endpoint only returns LLM models, not embedding models.

**Current behavior:**
- Only `letta/letta-free` embedding model appears in the UI/API
- OpenRouter embedding models (e.g., `openai/text-embedding-3-small`) are not discoverable

**Root cause:**
OpenRouter's `/models` endpoint doesn't list embedding models, but they support OpenAI's embedding models via the `/embeddings` endpoint.

## Solution

Added `list_embedding_models_async()` method to `OpenRouterProvider` class that returns hardcoded `EmbeddingConfig` objects for:
- `openai/text-embedding-3-small` (1536 dimensions)
- `openai/text-embedding-3-large` (3072 dimensions)

## Test plan

- [x] Added unit test `test_openrouter_embedding_models_without_api_key` that verifies embedding models are returned correctly without making API calls
- [x] Added integration test `test_openrouter` (requires `OPENROUTER_API_KEY`)

Fixes #3086