### PR TITLE
fix: remove unsupported 'user' parameter from OpenAI Responses API requests

### DIFF
--- a/branches/bugfix/openai-responses-user.md
+++ b/branches/bugfix/openai-responses-user.md
@@ -1,0 +1,63 @@
+# OpenAI Responses API `user` Parameter Fix
+
+## Issue Summary
+
+When using models that route through OpenAI's Responses API (`/v1/responses`), such as `gpt-5.2-codex`, requests fail with:
+
+```
+Error code: 400 - {'detail': 'Unsupported parameter: user'}
+```
+
+The OpenAI Responses API does not support the `user` parameter, but Letta unconditionally adds it to all OpenAI requests.
+
+## Root Cause
+
+Commit `9280d85ba` ("feat: always add user id to openai requests (#1969)") introduced code that unconditionally sets the `user` parameter on both Chat Completions and Responses API requests.
+
+The `build_request_data_responses` method in `openai_client.py` was setting the `user` field:
+
+```python
+# always set user id for openai requests
+if self.actor:
+    data.user = self.actor.id
+
+if llm_config.model_endpoint == LETTA_MODEL_ENDPOINT:
+    if not self.actor:
+        # override user id for inference.letta.com
+        import uuid
+
+        data.user = str(uuid.UUID(int=0))
+```
+
+However, the Responses API (`/v1/responses`) does not support this parameter.
+
+## The Fix
+
+Removed the `user` parameter assignment from `build_request_data_responses` method. The Chat Completions API (`/v1/chat/completions`) does support the `user` parameter, so the equivalent code in `build_request_data` method remains unchanged.
+
+```python
+# Note: Don't set 'user' param for Responses API - it's not supported
+# (see build_request_data for Chat Completions which does support it)
+```
+
+## Files Modified
+
+- `letta/llm_api/openai_client.py` - Removed `user` parameter from `build_request_data_responses` method
+
+## Testing
+
+After applying the fix:
+
+1. Rebuild the Docker image
+2. Test with a model that uses the Responses API (e.g., `gpt-5.2-codex`)
+3. Verify the request succeeds without the "Unsupported parameter: user" error
+
+## PR Recommendation
+
+This is a safe, minimal fix that:
+1. Removes unsupported parameter from Responses API requests
+2. Keeps `user` parameter for Chat Completions API (which supports it)
+3. Doesn't change behavior for standard OpenAI chat models
+4. Enables compatibility with newer GPT models that use the Responses API
+
+Should be safe to submit as a PR to upstream letta-ai/letta.

--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -371,17 +371,10 @@ class OpenAIClient(LLMClientBase):
         if tools and supports_parallel_tool_calling(model):
             data.parallel_tool_calls = llm_config.parallel_tool_calls
 
-        # always set user id for openai requests
-        if self.actor:
-            data.user = self.actor.id
+        # Note: Don't set 'user' param for Responses API - it's not supported
+        # (see build_request_data for Chat Completions which does support it)
 
         if llm_config.model_endpoint == LETTA_MODEL_ENDPOINT:
-            if not self.actor:
-                # override user id for inference.letta.com
-                import uuid
-
-                data.user = str(uuid.UUID(int=0))
-
             data.model = "memgpt-openai"
 
         request_data = data.model_dump(exclude_unset=True)


### PR DESCRIPTION
Hi Letta team! 👋

This PR fixes an issue where requests to the OpenAI Responses API (used by models like `gpt-5.2-codex`) fail with a 400 error due to an unsupported `user` parameter.

## Problem

When using models routed through OpenAI's Responses API (`/v1/responses`), requests fail with:
```
Error code: 400 - {'detail': 'Unsupported parameter: user'}
```
This happens because Letta unconditionally sets the `user` parameter for all OpenAI requests, but the Responses API does not support it.

## Evidence

The `user` parameter is not supported by the Responses API:
1. **[Azure OpenAI Responses API docs](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses)**: Lists all supported request parameters; `user` is not among them.
2. **[Roo-Code #6862](https://github.com/RooCodeInc/Roo-Code/issues/6862)**: Documents similar 400 errors for unsupported parameters in the Responses API.
3. **[API comparison guides](https://simonwillison.net/2025/Mar/11/responses-vs-chat-completions/)**: Do not mention `user` as available in the Responses API.
4. **[Chat Completions API reference](https://platform.openai.com/docs/api-reference/chat)**: Confirms `user` is a Chat Completions-specific parameter.

## Solution

I've removed the `user` parameter assignment from the `build_request_data_responses` method in `letta/llm_api/openai_client.py`. 

**Note**: The Chat Completions API (`/v1/chat/completions`) *does* support the `user` parameter, so the equivalent code in `build_request_data` remains unchanged.

Thanks for reviewing! Let me know if you have any questions.