### PR TITLE
fix: use correct client type for Azure embeddings in file processor

### DIFF
--- a/letta/services/file_processor/embedder/openai_embedder.py
+++ b/letta/services/file_processor/embedder/openai_embedder.py
@@ -1,9 +1,9 @@
 import asyncio
 import time
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, Tuple
 
 from letta.llm_api.llm_client import LLMClient
-from letta.llm_api.openai_client import OpenAIClient
+from letta.llm_api.llm_client_base import LLMClientBase
 from letta.log import get_logger
 from letta.otel.tracing import log_event, trace_method
 from letta.schemas.embedding_config import EmbeddingConfig
@@ -35,14 +35,11 @@ class OpenAIEmbedder(BaseEmbedder):
         )
         self.embedding_config = embedding_config or self.default_embedding_config
 
-        # TODO: Unify to global OpenAI client
-        self.client: OpenAIClient = cast(
-            OpenAIClient,
-            LLMClient.create(
-                provider_type=ProviderType.openai,
-                put_inner_thoughts_first=False,
-                actor=None,  # Not necessary
-            ),
+        # Use the correct client type based on embedding config's provider
+        self.client: LLMClientBase = LLMClient.create(
+            provider_type=ProviderType(self.embedding_config.embedding_endpoint_type),
+            put_inner_thoughts_first=False,
+            actor=None,
         )
 
     @trace_method


### PR DESCRIPTION
## Relevant issues

Fixes #3163 - Azure embedding requests return 404 due to malformed URL construction.

## Summary

The `OpenAIEmbedder` was hardcoded to always use `OpenAIClient` regardless of the `embedding_endpoint_type` in the config. This caused Azure embedding requests to fail with 404 errors because:

1. `OpenAIClient._prepare_client_kwargs_embedding()` uses `embedding_endpoint` as `base_url` for `AsyncOpenAI`
2. For Azure, `embedding_endpoint` contains the full deployment URL with `/embeddings` path already included  
3. The OpenAI SDK appends `/embeddings` again, resulting in a malformed URL like:
   `https://.../deployments/model/embeddings?api-version=.../embeddings`

**Fix:** Use `LLMClient.create()` with the `provider_type` from embedding config so Azure configs get `AzureClient` (which handles Azure URLs correctly via `AsyncAzureOpenAI`).

## Pre-Submission checklist

- [x] I have added testing in the `tests/` directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

- Modified `OpenAIEmbedder.__init__()` to use `ProviderType(embedding_config.embedding_endpoint_type)` instead of hardcoded `ProviderType.openai`
- Added regression tests verifying correct client selection for both Azure and OpenAI configs