### PR TITLE
feat: add grok-4-1-fast-reasoning model support

### DIFF
--- a/letta/schemas/providers/xai.py
+++ b/letta/schemas/providers/xai.py
@@ -18,7 +18,8 @@ MODEL_CONTEXT_WINDOWS = {
     "grok-4-0709": 256_000,
     "grok-4-fast-reasoning": 2_000_000,
     "grok-4-fast-non-reasoning": 2_000_000,
-    "grok-code-fast-1": 256_000
+    "grok-4-1-fast-reasoning": 2_000_000,
+    "grok-code-fast-1": 256_000,
 }
 
 


### PR DESCRIPTION
## Summary

Add context window configuration for the new xAI Grok 4.1 model (`grok-4-1-fast-reasoning`).

## Changes

- Added `grok-4-1-fast-reasoning` with 2M context window to `MODEL_CONTEXT_WINDOWS` in `xai.py`

## Test plan

- [x] Model now appears in `/v1/models` endpoint on self-hosted servers with xAI configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)