### PR TITLE
fix(azure): sanitize base_url to remove suffixes like /embeddings

### DIFF
--- a/letta/llm_api/azure_client.py
+++ b/letta/llm_api/azure_client.py
@@ -13,6 +13,15 @@ from letta.settings import model_settings
 
 
 class AzureClient(OpenAIClient):
+    def _sanitize_base_url(self, base_url: Optional[str]) -> Optional[str]:
+        if not base_url:
+            return base_url
+        base_url = base_url.rstrip("/")
+        for suffix in ["/embeddings", "/chat/completions", "/completions"]:
+            if base_url.endswith(suffix):
+                base_url = base_url[: -len(suffix)]
+        return base_url
+
     def get_byok_overrides(self, llm_config: LLMConfig) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         if llm_config.provider_category == ProviderCategory.byok:
             from letta.services.provider_manager import ProviderManager
@@ -40,6 +49,10 @@ class AzureClient(OpenAIClient):
             base_url = model_settings.azure_base_url or os.environ.get("AZURE_BASE_URL")
             api_version = model_settings.azure_api_version or os.environ.get("AZURE_API_VERSION")
 
+            api_version = model_settings.azure_api_version or os.environ.get("AZURE_API_VERSION")
+
+        base_url = self._sanitize_base_url(base_url)
+
         client = AzureOpenAI(api_key=api_key, azure_endpoint=base_url, api_version=api_version)
         response: ChatCompletion = client.chat.completions.create(**request_data)
         return response.model_dump()
@@ -55,6 +68,7 @@ class AzureClient(OpenAIClient):
             base_url = model_settings.azure_base_url or os.environ.get("AZURE_BASE_URL")
             api_version = model_settings.azure_api_version or os.environ.get("AZURE_API_VERSION")
         try:
+            base_url = self._sanitize_base_url(base_url)
             client = AsyncAzureOpenAI(api_key=api_key, azure_endpoint=base_url, api_version=api_version)
             response: ChatCompletion = await client.chat.completions.create(**request_data)
         except Exception as e:
@@ -68,6 +82,7 @@ class AzureClient(OpenAIClient):
         api_key = model_settings.azure_api_key or os.environ.get("AZURE_API_KEY")
         base_url = model_settings.azure_base_url or os.environ.get("AZURE_BASE_URL")
         api_version = model_settings.azure_api_version or os.environ.get("AZURE_API_VERSION")
+        base_url = self._sanitize_base_url(base_url)
         client = AsyncAzureOpenAI(api_key=api_key, api_version=api_version, azure_endpoint=base_url)
         response = await client.embeddings.create(model=embedding_config.embedding_model, input=inputs)
 


### PR DESCRIPTION
Fixes #3163. This PR ensures that `AZURE_BASE_URL` (and BYOK base URLs) is sanitized to remove suffixes like `/embeddings`, `/chat/completions`, etc., before passing it to the Azure OpenAI SDK. This prevents the SDK from constructing malformed URLs (e.g., doubling the path).