### PR TITLE
fix: correct typos 'occured' and 'occurences'

### DIFF
--- a/letta/agents/letta_agent_v3.py
+++ b/letta/agents/letta_agent_v3.py
@@ -808,7 +808,7 @@ class LettaAgentV3(LettaAgentV2):
                                 raise e
                             except Exception as e:
                                 self.stop_reason = LettaStopReason(stop_reason=StopReasonType.error.value)
-                                self.logger.error(f"Unknown error occured for summarization run {run_id}: {e}")
+                                self.logger.error(f"Unknown error occurred for summarization run {run_id}: {e}")
                                 raise e
 
                             # update the messages
@@ -821,7 +821,7 @@ class LettaAgentV3(LettaAgentV2):
 
                         else:
                             self.stop_reason = LettaStopReason(stop_reason=StopReasonType.error.value)
-                            self.logger.error(f"Unknown error occured for run {run_id}: {e}")
+                            self.logger.error(f"Unknown error occurred for run {run_id}: {e}")
                             raise e
 
                 step_progression, step_metrics = self._step_checkpoint_llm_request_finish(

--- a/letta/functions/function_sets/base.py
+++ b/letta/functions/function_sets/base.py
@@ -359,10 +359,10 @@ def memory_replace(agent_state: "AgentState", label: str, old_str: str, new_str:
     current_value = str(agent_state.memory.get_block(label).value).expandtabs()
 
     # Check if old_str is unique in the block
-    occurences = current_value.count(old_str)
-    if occurences == 0:
+    occurrences = current_value.count(old_str)
+    if occurrences == 0:
         raise ValueError(f"No replacement was performed, old_str `{old_str}` did not appear verbatim in memory block with label `{label}`.")
-    elif occurences > 1:
+    elif occurrences > 1:
         content_value_lines = current_value.split("\n")
         lines = [idx + 1 for idx, line in enumerate(content_value_lines) if old_str in line]
         raise ValueError(

--- a/letta/schemas/letta_message.py
+++ b/letta/schemas/letta_message.py
@@ -405,7 +405,7 @@ class SummaryMessage(LettaMessage):
 
 class EventMessage(LettaMessage):
     """
-    A message for notifying the developer that an event that has occured (e.g. a compaction). Events are NOT part of the context window.
+    A message for notifying the developer that an event that has occurred (e.g. a compaction). Events are NOT part of the context window.
     """
 
     message_type: Literal["event"] = "event_message"

--- a/letta/services/tool_executor/core_tool_executor.py
+++ b/letta/services/tool_executor/core_tool_executor.py
@@ -373,12 +373,12 @@ class LettaCoreToolExecutor(ToolExecutor):
         current_value = str(agent_state.memory.get_block(label).value).expandtabs()
 
         # Check if old_str is unique in the block
-        occurences = current_value.count(old_str)
-        if occurences == 0:
+        occurrences = current_value.count(old_str)
+        if occurrences == 0:
             raise ValueError(
                 f"No replacement was performed, old_str `{old_str}` did not appear verbatim in memory block with label `{label}`."
             )
-        elif occurences > 1:
+        elif occurrences > 1:
             content_value_lines = current_value.split("\n")
             lines = [idx + 1 for idx, line in enumerate(content_value_lines) if old_str in line]
             raise ValueError(
@@ -949,12 +949,12 @@ class LettaCoreToolExecutor(ToolExecutor):
         current_value = str(memory_block.value).expandtabs()
 
         # Check if old_str is unique in the block
-        occurences = current_value.count(old_str)
-        if occurences == 0:
+        occurrences = current_value.count(old_str)
+        if occurrences == 0:
             raise ValueError(
                 f"No replacement was performed, old_str `{old_str}` did not appear verbatim in memory block with label `{label}`."
             )
-        elif occurences > 1:
+        elif occurrences > 1:
             content_value_lines = current_value.split("\n")
             lines = [idx + 1 for idx, line in enumerate(content_value_lines) if old_str in line]
             raise ValueError(


### PR DESCRIPTION
Fixes spelling errors in log messages, docstrings, and variable names:
- 'occured' → 'occurred'
- 'occurences' → 'occurrences'