### PR TITLE
fix: update pgvector image from ankane/pgvector to pgvector/pgvector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with pgvector base for builder
-FROM ankane/pgvector:v0.5.1 AS builder
+FROM pgvector/pgvector:pg17 AS builder
 # comment to trigger ci
 # Install Python and required packages
 RUN apt-get update && apt-get install -y \
@@ -39,7 +39,7 @@ COPY . .
 RUN uv sync --frozen --no-dev --all-extras --python 3.11
 
 # Runtime stage
-FROM ankane/pgvector:v0.5.1 AS runtime
+FROM pgvector/pgvector:pg17 AS runtime
 
 # Overridable Node.js version with --build-arg NODE_VERSION
 ARG NODE_VERSION=22

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: ankane/pgvector:v0.5.1
+    image: pgvector/pgvector:pg17
     networks:
       default:
         aliases:

--- a/db/Dockerfile.simple
+++ b/db/Dockerfile.simple
@@ -43,10 +43,10 @@
 # where user, password, and db are the values you set in the init-letta.sql file,
 # all defaulting to 'letta'.
 
-# Version tags can be found here: https://hub.docker.com/r/ankane/pgvector/tags
-ARG PGVECTOR=v0.5.1
+# Version tags can be found here: https://hub.docker.com/r/pgvector/pgvector/tags
+ARG PGVECTOR=pg17
 # Set up a minimal postgres image
-FROM ankane/pgvector:${PGVECTOR}
+FROM pgvector/pgvector:${PGVECTOR}
 RUN sed -e 's/^    //' >/docker-entrypoint-initdb.d/01-initletta.sql <<'EOF'
     -- Title: Init Letta Database
 

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -1,6 +1,6 @@
 services:
   letta_db:
-    image: ankane/pgvector:v0.5.1
+    image: pgvector/pgvector:pg17
     networks:
       default:
         aliases:

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes
   postgres:
-    image: ankane/pgvector
+    image: pgvector/pgvector:pg17
     container_name: postgres
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']


### PR DESCRIPTION
## Summary

- Updates the pgvector Docker base image from the outdated `ankane/pgvector:v0.5.1` to the actively maintained `pgvector/pgvector:pg17` across all Docker configuration files
- The `ankane/pgvector` image hasn't been updated in over 2 years and uses PostgreSQL 15, which poses security concerns
- This aligns the Dockerfile and compose files with the CI workflows, which already use `pgvector/pgvector:pg17`

### Files changed

- `Dockerfile` — both builder and runtime stages
- `compose.yaml` — letta_db service
- `dev-compose.yaml` — letta_db service
- `db/Dockerfile.simple` — base image ARG and FROM, plus Docker Hub URL in comment
- `scripts/docker-compose.yml` — postgres service

Fixes #3136

## Test plan

- [ ] Verify `docker compose up` starts successfully with the new image
- [ ] Verify the Letta server connects to PostgreSQL and pgvector extension loads correctly
- [ ] Verify `docker build -f db/Dockerfile.simple .` builds successfully
- [ ] Confirm CI workflows continue to pass (they already use `pgvector/pgvector:pg17`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)