### PR TITLE
fix: secure the final Docker EOL release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,6 +28,18 @@ jobs:
       id: extract_version
       run: echo "CURRENT_VERSION=$(awk -F '\"' '/version =/ { print $2 }' pyproject.toml | head -n 1)" >> $GITHUB_ENV
 
+    - name: Build release image for security smoke test
+      uses: docker/build-push-action@v6
+      with:
+        load: true
+        tags: letta-eol-test:${{ github.sha }}
+        build-args: |
+          LETTA_VERSION=${{ env.CURRENT_VERSION }}
+          LETTA_DOCKER_EOL=true
+
+    - name: Verify secure EOL defaults
+      run: ./scripts/test_docker_security.sh letta-eol-test:${{ github.sha }}
+
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
@@ -36,5 +48,9 @@ jobs:
         tags: |
           letta/letta:${{ env.CURRENT_VERSION }}
           letta/letta:latest
+          letta/letta:nightly
           memgpt/letta:${{ env.CURRENT_VERSION }}
           memgpt/letta:latest
+        build-args: |
+          LETTA_VERSION=${{ env.CURRENT_VERSION }}
+          LETTA_DOCKER_EOL=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ARG LETTA_ENVIRONMENT=DEV
 ENV LETTA_ENVIRONMENT=${LETTA_ENVIRONMENT} \
     UV_NO_PROGRESS=1 \
     UV_PYTHON_PREFERENCE=system \
+    UV_HTTP_TIMEOUT=120 \
     UV_CACHE_DIR=/tmp/uv_cache
 
 # Set for other builds
@@ -36,7 +37,8 @@ COPY pyproject.toml uv.lock ./
 # Then copy the rest of the application code
 COPY . .
 
-RUN uv sync --frozen --no-dev --all-extras --python 3.11
+RUN --mount=type=cache,target=/tmp/uv_cache \
+    uv sync --frozen --no-dev --all-extras --python 3.11
 
 # Runtime stage
 FROM pgvector/pgvector:0.8.1-pg15 AS runtime
@@ -85,7 +87,9 @@ ENV LETTA_ENVIRONMENT=${LETTA_ENVIRONMENT} \
     POSTGRES_DB=letta
 
 ARG LETTA_VERSION
-ENV LETTA_VERSION=${LETTA_VERSION}
+ARG LETTA_DOCKER_EOL=false
+ENV LETTA_VERSION=${LETTA_VERSION} \
+    LETTA_DOCKER_EOL=${LETTA_DOCKER_EOL}
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Build AI with advanced memory that can learn and self-improve over time.
 > [!NOTE]
 > This repository contains the legacy Letta server (the API server behind the Letta V1 API and SDKs). Active development has moved to the [Letta Agent repo](https://github.com/letta-ai/letta-code), and self-hosting an API server is now done via the [App Server](https://docs.letta.com/letta-agent/app-server). See [AGENTS.md](AGENTS.md) for details.
 
+> [!WARNING]
+> The `letta/letta` Docker distribution is end-of-life and unsupported. Version 0.16.9 is its final maintenance release and enables password authentication by default. Migrate to the [Letta App Server](https://docs.letta.com/letta-agent/app-server).
+
 ## Get started in the CLI
 
 Requires [Node.js 22.19+](https://nodejs.org/en/download)

--- a/letta/server/startup.sh
+++ b/letta/server/startup.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e  # Exit on any error
 
+# Only the final public Docker release sets LETTA_DOCKER_EOL; other builds keep their existing startup behavior.
+if [ "${LETTA_DOCKER_EOL:-false}" = "true" ]; then
+    cat >&2 <<'EOF'
+WARNING: The letta/letta Docker distribution is end-of-life and unsupported.
+This final maintenance release enables password authentication by default.
+Migrate to the Letta App Server: https://docs.letta.com/letta-agent/app-server
+EOF
+fi
+
 HOST="${HOST:-0.0.0.0}"
 PORT="${PORT:-8283}"
 
@@ -70,9 +79,17 @@ if [ -n "$LETTA_SANDBOX_MOUNT_PATH" ]; then
     fi
 fi
 
-# If ADE is enabled, add the --ade flag to the command
 CMD="letta server --host $HOST --port $PORT"
-if [ "${SECURE:-false}" = "true" ]; then
+if [ "${LETTA_DOCKER_EOL:-false}" = "true" ]; then
+    if [ "${LETTA_ALLOW_INSECURE_HTTP:-false}" = "true" ]; then
+        cat >&2 <<'EOF'
+WARNING: LETTA_ALLOW_INSECURE_HTTP=true disables authentication.
+Only use this compatibility escape hatch on an isolated, trusted network.
+EOF
+    else
+        CMD="$CMD --secure"
+    fi
+elif [ "${SECURE:-false}" = "true" ]; then
     CMD="$CMD --secure"
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "letta"
-version = "0.16.8"
+version = "0.16.9"
 description = "Create LLM agents with long-term memory and custom tools"
 authors = [
     {name = "Letta Team", email = "contact@letta.com"},

--- a/scripts/test_docker_security.sh
+++ b/scripts/test_docker_security.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+IMAGE="${1:?usage: test_docker_security.sh IMAGE}"
+EXPECT_EOL="${EXPECT_EOL:-true}"
+NAME="letta-docker-security-$$"
+RESPONSE_FILE="$(mktemp)"
+
+cleanup() {
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+    rm -f "$RESPONSE_FILE"
+}
+trap cleanup EXIT INT TERM
+
+docker run --detach --name "$NAME" --publish 127.0.0.1::8283 "$IMAGE" >/dev/null
+PORT="$(docker port "$NAME" 8283/tcp | sed -n 's/.*://p' | head -n 1)"
+
+attempt=0
+until curl --fail --silent "http://127.0.0.1:$PORT/v1/health/" >/dev/null; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 120 ]; then
+        docker logs "$NAME" >&2
+        echo "Timed out waiting for the Docker server" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+if [ "$EXPECT_EOL" = "true" ] && ! docker logs "$NAME" 2>&1 | grep -q "Docker distribution is end-of-life and unsupported"; then
+    echo "Docker startup did not print the EOL warning" >&2
+    exit 1
+fi
+
+STATUS="$(curl --silent --output "$RESPONSE_FILE" --write-out '%{http_code}' \
+    --request POST "http://127.0.0.1:$PORT/v1/tools/run" \
+    --header 'content-type: application/json' \
+    --data '{"name":"authorization_probe","source_code":"def authorization_probe():\n return \"request reached tool execution\"","args":{}}')"
+
+if [ "$STATUS" != "401" ]; then
+    echo "Expected unauthenticated tool execution to return 401, got $STATUS" >&2
+    cat "$RESPONSE_FILE" >&2
+    exit 1
+fi
+
+PASSWORD="$(docker logs "$NAME" 2>&1 | sed -n 's/.*Using secure mode with password: //p' | tail -n 1)"
+if [ -z "$PASSWORD" ]; then
+    echo "Could not read the generated server password from Docker logs" >&2
+    exit 1
+fi
+
+STATUS="$(curl --silent --output "$RESPONSE_FILE" --write-out '%{http_code}' \
+    --request POST "http://127.0.0.1:$PORT/v1/tools/run" \
+    --header 'content-type: application/json' \
+    --header "Authorization: Bearer $PASSWORD" \
+    --data '{"name":"authorized_smoke_test","source_code":"def authorized_smoke_test():\n return \"authorized\"","args":{}}')"
+
+if [ "$STATUS" != "200" ] || ! grep -q '"tool_return":"authorized"' "$RESPONSE_FILE"; then
+    echo "Authenticated compatibility smoke test failed with status $STATUS" >&2
+    cat "$RESPONSE_FILE" >&2
+    exit 1
+fi
+
+echo "Docker EOL security checks passed"

--- a/tests/test_docker_startup.py
+++ b/tests/test_docker_startup.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+from pathlib import Path
+
+STARTUP_SCRIPT = Path(__file__).parents[1] / "letta" / "server" / "startup.sh"
+
+
+def _write_stub(bin_dir: Path, name: str, body: str) -> None:
+    path = bin_dir / name
+    path.write_text(f"#!/bin/sh\n{body}\n")
+    path.chmod(0o755)
+
+
+def _run_startup(tmp_path: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir, "alembic", "exit 0")
+    _write_stub(bin_dir, "otelcol-contrib", "exit 0")
+    _write_stub(bin_dir, "letta", "printf 'LETTA_COMMAND=%s\\n' \"$*\"")
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "LETTA_PG_URI": "postgresql://external/test",
+        "LETTA_REDIS_HOST": "external-redis",
+    }
+    env.pop("LETTA_ALLOW_INSECURE_HTTP", None)
+    env.pop("LETTA_DOCKER_EOL", None)
+    env.pop("LETTA_SERVER_SECURE", None)
+    env.pop("SECURE", None)
+    env.update(overrides)
+    return subprocess.run(
+        [str(STARTUP_SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def test_eol_docker_startup_is_secure_by_default(tmp_path: Path) -> None:
+    result = _run_startup(tmp_path, LETTA_DOCKER_EOL="true")
+    output = result.stdout + result.stderr
+
+    assert "Docker distribution is end-of-life and unsupported" in output
+    assert "LETTA_COMMAND=server --host 0.0.0.0 --port 8283 --secure" in output
+
+
+def test_eol_docker_startup_requires_explicit_unsafe_opt_out(tmp_path: Path) -> None:
+    result = _run_startup(tmp_path, LETTA_DOCKER_EOL="true", LETTA_ALLOW_INSECURE_HTTP="true")
+    output = result.stdout + result.stderr
+
+    assert "LETTA_ALLOW_INSECURE_HTTP=true disables authentication" in output
+    assert "LETTA_COMMAND=server --host 0.0.0.0 --port 8283" in output
+    assert "--secure" not in output
+
+
+def test_non_eol_startup_is_unchanged(tmp_path: Path) -> None:
+    result = _run_startup(tmp_path)
+    output = result.stdout + result.stderr
+
+    assert "Docker distribution is end-of-life" not in output
+    assert "LETTA_COMMAND=server --host 0.0.0.0 --port 8283" in output
+    assert "--secure" not in output
+
+
+def test_existing_secure_flag_still_enables_authentication(tmp_path: Path) -> None:
+    result = _run_startup(tmp_path, SECURE="true")
+    output = result.stdout + result.stderr
+
+    assert "Docker distribution is end-of-life" not in output
+    assert "LETTA_COMMAND=server --host 0.0.0.0 --port 8283 --secure" in output

--- a/uv.lock
+++ b/uv.lock
@@ -2510,7 +2510,7 @@ wheels = [
 
 [[package]]
 name = "letta"
-version = "0.16.8"
+version = "0.16.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- ship 0.16.9 as the final `letta/letta` maintenance release, with an EOL notice and App Server migration path
- enable generated-password authentication by default only in official EOL builds; retain an explicit `LETTA_ALLOW_INSECURE_HTTP=true` compatibility escape hatch
- move `latest`, `nightly`, and the legacy `memgpt/letta` aliases to the secured final image, and block publishing unless a built image passes the authorization smoke test

## Before / after

Before, a no-configuration 0.16.8 container returned HTTP 200 to an unauthenticated `/v1/tools/run` request and executed the harmless probe. With this patch's release build argument, the same request returns HTTP 401. Reading the generated password from startup logs and retrying with bearer authentication returns HTTP 200 and the exact expected tool result.

Builds without `LETTA_DOCKER_EOL=true` preserve existing startup behavior; only official EOL Docker builds enable the new default.

## Validation

- published `letta/letta:0.16.8` failed the new authorization regression as expected: unauthenticated request returned 200
- `docker build --tag letta-eol-security:public --build-arg LETTA_VERSION=0.16.9 --build-arg LETTA_DOCKER_EOL=true .` — passed on arm64
- `scripts/test_docker_security.sh letta-eol-security:public` — passed (EOL notice, unauthenticated 401, authenticated 200 with exact tool result)
- `pytest -q tests/test_docker_startup.py` — 4 passed
- the 0.16.8 startup script fails the secure-EOL unit regression
- `sh -n`, `uv lock --check`, workflow YAML parse, and `git diff --check` passed

## Risk / release notes

- The GitHub workflow smoke-tests its native amd64 image before the existing amd64/arm64 publish. The same Dockerfile and smoke test also passed locally on arm64.
- The legacy image still starts the server as root because it also owns bundled PostgreSQL, Redis, and telemetry process startup. This closes the reported unauthenticated path but does not claim container privilege isolation.
- Merging this PR does not publish anything. Dispatch the Docker workflow from reviewed 0.16.9 source after merge. Publishing a GitHub Release would also trigger the legacy PyPI workflow, so that should be a separate explicit decision.

## AI disclosure

This implementation and PR text were AI-assisted using Letta Code (Overlord, `agent-c2adbf5c-8419-4211-8cd8-3740db164974`). The change was source-reviewed and validated against both the published vulnerable image and the patched real container boundary.
